### PR TITLE
Align JRE from .classpath with Bundle-RequiredExecutionEnvironment

### DIFF
--- a/plugins/org.springframework.ide.eclipse.data.core.tests/.classpath
+++ b/plugins/org.springframework.ide.eclipse.data.core.tests/.classpath
@@ -2,6 +2,6 @@
 <classpath>
 	<classpathentry kind="src" path="src/test/java"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>


### PR DESCRIPTION
Bundle-RequiredExecutionEnvironment requires Java 1.5, which is perfectly fine here.
