### PR TITLE
STS-3852 fix. 

### DIFF
--- a/plugins/org.springframework.ide.eclipse.beans.core/plugin.xml
+++ b/plugins/org.springframework.ide.eclipse.beans.core/plugin.xml
@@ -105,6 +105,11 @@
 	            </property>
 	            <message id="CLASS_NOT_CLASS" label="Class is interface" severity="WARNING" />
 	            <message id="CLASS_NOT_FOUND" label="Class not found" severity="ERROR" />
+           <message
+                 id="CLASS_NOT_CONCRETE"
+                 label="Class is abstract"
+                 severity="WARNING">
+           </message>
      	    </rule>
 		    <rule id="toolAnnotation"
             		class="org.springframework.ide.eclipse.beans.core.internal.model.validation.rules.NamespaceElementsRule"

--- a/plugins/org.springframework.ide.eclipse.beans.core/src/org/springframework/ide/eclipse/beans/core/internal/model/validation/BeansConfigReloadingProjectContributionEventListener.java
+++ b/plugins/org.springframework.ide.eclipse.beans.core/src/org/springframework/ide/eclipse/beans/core/internal/model/validation/BeansConfigReloadingProjectContributionEventListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2013 Spring IDE Developers
+ * Copyright (c) 2009, 2014 Spring IDE Developers
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -36,7 +36,6 @@ import org.springframework.ide.eclipse.beans.core.model.IBeansImport;
 import org.springframework.ide.eclipse.beans.core.model.IBeansProject;
 import org.springframework.ide.eclipse.beans.core.model.IImportedBeansConfig;
 import org.springframework.ide.eclipse.beans.core.model.IReloadableBeansConfig;
-import org.springframework.ide.eclipse.core.SpringCoreUtils;
 import org.springframework.ide.eclipse.core.internal.model.validation.ValidatorDefinition;
 import org.springframework.ide.eclipse.core.java.ITypeStructureCache;
 import org.springframework.ide.eclipse.core.java.JdtUtils;
@@ -46,6 +45,7 @@ import org.springframework.ide.eclipse.core.project.IProjectContributionEventLis
 import org.springframework.ide.eclipse.core.project.IProjectContributorState;
 import org.springframework.ide.eclipse.core.project.ProjectBuilderDefinition;
 import org.springframework.ide.eclipse.core.project.ProjectContributionEventListenerAdapter;
+import org.springsource.ide.eclipse.commons.core.SpringCoreUtils;
 
 /**
  * {@link IProjectContributionEventListener} implementation that handles resetting of {@link IBeansConfig}s based on

--- a/plugins/org.springframework.ide.eclipse.beans.core/src/org/springframework/ide/eclipse/beans/core/internal/model/validation/rules/AbstractBeanMethodValidationRule.java
+++ b/plugins/org.springframework.ide.eclipse.beans.core/src/org/springframework/ide/eclipse/beans/core/internal/model/validation/rules/AbstractBeanMethodValidationRule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2010 Spring IDE Developers
+ * Copyright (c) 2007, 2014 Spring IDE Developers
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,11 +16,11 @@ import org.eclipse.jdt.core.JavaModelException;
 import org.springframework.ide.eclipse.beans.core.model.IBean;
 import org.springframework.ide.eclipse.beans.core.model.validation.AbstractBeanValidationRule;
 import org.springframework.ide.eclipse.beans.core.model.validation.IBeansValidationContext;
-import org.springframework.ide.eclipse.core.SpringCoreUtils;
 import org.springframework.ide.eclipse.core.java.Introspector;
 import org.springframework.ide.eclipse.core.java.Introspector.Public;
 import org.springframework.ide.eclipse.core.java.Introspector.Static;
 import org.springframework.ide.eclipse.core.model.validation.ValidationProblemAttribute;
+import org.springsource.ide.eclipse.commons.core.SpringCoreUtils;
 
 /**
  * Base class for valdating a given {@link IBean}'s methods.

--- a/plugins/org.springframework.ide.eclipse.beans.core/src/org/springframework/ide/eclipse/beans/core/internal/model/validation/rules/BeanClassRule.java
+++ b/plugins/org.springframework.ide.eclipse.beans.core/src/org/springframework/ide/eclipse/beans/core/internal/model/validation/rules/BeanClassRule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2010 Spring IDE Developers
+ * Copyright (c) 2007, 2014 Spring IDE Developers
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,6 +15,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.Flags;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
 import org.springframework.ide.eclipse.beans.core.internal.model.Bean;
@@ -22,12 +23,12 @@ import org.springframework.ide.eclipse.beans.core.internal.model.BeansModelUtils
 import org.springframework.ide.eclipse.beans.core.model.IBean;
 import org.springframework.ide.eclipse.beans.core.model.validation.AbstractBeanValidationRule;
 import org.springframework.ide.eclipse.beans.core.model.validation.IBeansValidationContext;
-import org.springframework.ide.eclipse.core.SpringCoreUtils;
 import org.springframework.ide.eclipse.core.java.JdtUtils;
 import org.springframework.ide.eclipse.core.model.IModelSourceLocation;
 import org.springframework.ide.eclipse.core.model.java.JavaModelSourceLocation;
 import org.springframework.ide.eclipse.core.model.validation.ValidationProblemAttribute;
 import org.springframework.util.StringUtils;
+import org.springsource.ide.eclipse.commons.core.SpringCoreUtils;
 
 /**
  * Validates a given {@link IBean}'s bean class. Skips child beans and bean class names with placeholders.
@@ -61,13 +62,19 @@ public class BeanClassRule extends AbstractBeanValidationRule {
 			IType type = JdtUtils.getJavaType(BeansModelUtils.getProject(bean).getProject(), className);
 			try {
 				IModelSourceLocation sourceLocation = bean.getElementSourceLocation();
-				if (type != null && type.isInterface()
-						&& !(sourceLocation instanceof JavaModelSourceLocation)) {
-					context.warning(bean, "CLASS_NOT_CLASS", "Class '" + className + "' is an interface",
-							new ValidationProblemAttribute("CLASS", className), 
-							new ValidationProblemAttribute("BEAN_NAME", bean.getElementName()));
-				}
-				else if (type == null) {
+				if (type != null) {
+					if (!bean.isAbstract() && !(sourceLocation instanceof JavaModelSourceLocation)) {
+						if (type.isInterface()) {
+							context.warning(bean, "CLASS_NOT_CLASS", "Class '" + className + "' is an interface",
+									new ValidationProblemAttribute("CLASS", className), 
+									new ValidationProblemAttribute("BEAN_NAME", bean.getElementName()));
+						} else if (type.isClass() && Flags.isAbstract(type.getFlags())) {
+							context.warning(bean, "CLASS_NOT_CONCRETE", "Class '" + className + "' is abstract ",
+									new ValidationProblemAttribute("CLASS", className), 
+									new ValidationProblemAttribute("BEAN_NAME", bean.getElementName()));
+						}
+					}
+				} else {
 					context.error(bean, "CLASS_NOT_FOUND", "Class '" + className + "' not found",
 							new ValidationProblemAttribute("CLASS", className), 
 							new ValidationProblemAttribute("BEAN_NAME", bean.getElementName()));

--- a/plugins/org.springframework.ide.eclipse.beans.core/src/org/springframework/ide/eclipse/beans/core/internal/model/validation/rules/BeanConstructorArgumentRule.java
+++ b/plugins/org.springframework.ide.eclipse.beans.core/src/org/springframework/ide/eclipse/beans/core/internal/model/validation/rules/BeanConstructorArgumentRule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2013 Spring IDE Developers
+ * Copyright (c) 2007, 2014 Spring IDE Developers
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -37,7 +37,6 @@ import org.springframework.ide.eclipse.beans.core.model.IBean;
 import org.springframework.ide.eclipse.beans.core.model.IBeanConstructorArgument;
 import org.springframework.ide.eclipse.beans.core.model.validation.AbstractBeanValidationRule;
 import org.springframework.ide.eclipse.beans.core.model.validation.IBeansValidationContext;
-import org.springframework.ide.eclipse.core.SpringCoreUtils;
 import org.springframework.ide.eclipse.core.java.Introspector;
 import org.springframework.ide.eclipse.core.java.JdtUtils;
 import org.springframework.ide.eclipse.core.model.ISourceModelElement;
@@ -46,6 +45,7 @@ import org.springframework.ide.eclipse.core.type.asm.AnnotationMetadataReadingVi
 import org.springframework.ide.eclipse.core.type.asm.ClassReaderFactory;
 import org.springframework.ide.eclipse.core.type.asm.EmptyAnnotationVisitor;
 import org.springframework.ide.eclipse.core.type.asm.EmptyMethodVisitor;
+import org.springsource.ide.eclipse.commons.core.SpringCoreUtils;
 
 /**
  * Validates a given {@link IBean}'s constructor argument. Skips abstract beans and those beans that use a

--- a/plugins/org.springframework.ide.eclipse.beans.core/src/org/springframework/ide/eclipse/beans/core/internal/model/validation/rules/BeanDeprecationRule.java
+++ b/plugins/org.springframework.ide.eclipse.beans.core/src/org/springframework/ide/eclipse/beans/core/internal/model/validation/rules/BeanDeprecationRule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2010 Spring IDE Developers
+ * Copyright (c) 2009, 2014 Spring IDE Developers
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -23,15 +23,15 @@ import org.springframework.ide.eclipse.beans.core.model.IBeanProperty;
 import org.springframework.ide.eclipse.beans.core.model.IBeansModelElement;
 import org.springframework.ide.eclipse.beans.core.model.validation.AbstractNonInfrastructureBeanValidationRule;
 import org.springframework.ide.eclipse.beans.core.model.validation.IBeansValidationContext;
-import org.springframework.ide.eclipse.core.SpringCoreUtils;
 import org.springframework.ide.eclipse.core.java.Introspector;
-import org.springframework.ide.eclipse.core.java.JdtUtils;
 import org.springframework.ide.eclipse.core.java.Introspector.Public;
 import org.springframework.ide.eclipse.core.java.Introspector.Static;
+import org.springframework.ide.eclipse.core.java.JdtUtils;
 import org.springframework.ide.eclipse.core.model.IModelElement;
 import org.springframework.ide.eclipse.core.model.IResourceModelElement;
 import org.springframework.ide.eclipse.core.model.validation.IValidationRule;
 import org.springframework.ide.eclipse.core.model.validation.ValidationProblemAttribute;
+import org.springsource.ide.eclipse.commons.core.SpringCoreUtils;
 
 /**
  * Validates a given {@link IBean}'s bean class for deprecation.

--- a/plugins/org.springframework.ide.eclipse.beans.core/src/org/springframework/ide/eclipse/beans/core/internal/model/validation/rules/BeanFactoryRule.java
+++ b/plugins/org.springframework.ide.eclipse.beans.core/src/org/springframework/ide/eclipse/beans/core/internal/model/validation/rules/BeanFactoryRule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2010 Spring IDE Developers
+ * Copyright (c) 2007, 2014 Spring IDE Developers
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -21,11 +21,11 @@ import org.springframework.ide.eclipse.beans.core.internal.model.Bean;
 import org.springframework.ide.eclipse.beans.core.internal.model.BeansModelUtils;
 import org.springframework.ide.eclipse.beans.core.model.IBean;
 import org.springframework.ide.eclipse.beans.core.model.validation.IBeansValidationContext;
-import org.springframework.ide.eclipse.core.SpringCoreUtils;
 import org.springframework.ide.eclipse.core.java.Introspector.Static;
 import org.springframework.ide.eclipse.core.java.JdtUtils;
 import org.springframework.ide.eclipse.core.model.validation.ValidationProblemAttribute;
 import org.springframework.scripting.ScriptFactory;
+import org.springsource.ide.eclipse.commons.core.SpringCoreUtils;
 
 /**
  * Validates a given {@link IBean}'s factory bean and factory method.

--- a/plugins/org.springframework.ide.eclipse.beans.core/src/org/springframework/ide/eclipse/beans/core/internal/model/validation/rules/BeanMethodOverrideRule.java
+++ b/plugins/org.springframework.ide.eclipse.beans.core/src/org/springframework/ide/eclipse/beans/core/internal/model/validation/rules/BeanMethodOverrideRule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2009 Spring IDE Developers
+ * Copyright (c) 2007, 2014 Spring IDE Developers
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,10 +24,10 @@ import org.springframework.ide.eclipse.beans.core.model.IBean;
 import org.springframework.ide.eclipse.beans.core.model.IBeanMethodOverride;
 import org.springframework.ide.eclipse.beans.core.model.validation.AbstractNonInfrastructureBeanValidationRule;
 import org.springframework.ide.eclipse.beans.core.model.validation.IBeansValidationContext;
-import org.springframework.ide.eclipse.core.SpringCoreUtils;
 import org.springframework.ide.eclipse.core.java.Introspector;
 import org.springframework.ide.eclipse.core.model.IModelElement;
 import org.springframework.ide.eclipse.core.model.validation.IValidationRule;
+import org.springsource.ide.eclipse.commons.core.SpringCoreUtils;
 
 /**
  * Validates a given {@link IBeanMethodOverride#getBeanName()} in bean class.

--- a/plugins/org.springframework.ide.eclipse.beans.core/src/org/springframework/ide/eclipse/beans/core/internal/model/validation/rules/BeanPropertyRule.java
+++ b/plugins/org.springframework.ide.eclipse.beans.core/src/org/springframework/ide/eclipse/beans/core/internal/model/validation/rules/BeanPropertyRule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2010 Spring IDE Developers
+ * Copyright (c) 2007, 2014 Spring IDE Developers
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -25,16 +25,16 @@ import org.springframework.ide.eclipse.beans.core.model.IBean;
 import org.springframework.ide.eclipse.beans.core.model.IBeanProperty;
 import org.springframework.ide.eclipse.beans.core.model.validation.AbstractNonInfrastructureBeanValidationRule;
 import org.springframework.ide.eclipse.beans.core.model.validation.IBeansValidationContext;
-import org.springframework.ide.eclipse.core.SpringCoreUtils;
 import org.springframework.ide.eclipse.core.java.Introspector;
-import org.springframework.ide.eclipse.core.java.JdtUtils;
 import org.springframework.ide.eclipse.core.java.Introspector.Public;
 import org.springframework.ide.eclipse.core.java.Introspector.Static;
+import org.springframework.ide.eclipse.core.java.JdtUtils;
 import org.springframework.ide.eclipse.core.model.IModelElement;
 import org.springframework.ide.eclipse.core.model.validation.IValidationRule;
 import org.springframework.ide.eclipse.core.model.validation.ValidationProblemAttribute;
 import org.springframework.scripting.ScriptFactory;
 import org.springframework.util.StringUtils;
+import org.springsource.ide.eclipse.commons.core.SpringCoreUtils;
 
 /**
  * Validates a given {@link IBeanProperty}'s accessor methods in bean class.

--- a/plugins/org.springframework.ide.eclipse.beans.core/src/org/springframework/ide/eclipse/beans/core/internal/model/validation/rules/BeanReferenceRule.java
+++ b/plugins/org.springframework.ide.eclipse.beans.core/src/org/springframework/ide/eclipse/beans/core/internal/model/validation/rules/BeanReferenceRule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2010 Spring IDE Developers
+ * Copyright (c) 2007, 2014 Spring IDE Developers
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -37,7 +37,6 @@ import org.springframework.ide.eclipse.beans.core.model.IBeansSet;
 import org.springframework.ide.eclipse.beans.core.model.IBeansValueHolder;
 import org.springframework.ide.eclipse.beans.core.model.validation.AbstractNonInfrastructureBeanValidationRule;
 import org.springframework.ide.eclipse.beans.core.model.validation.IBeansValidationContext;
-import org.springframework.ide.eclipse.core.SpringCoreUtils;
 import org.springframework.ide.eclipse.core.java.JdtUtils;
 import org.springframework.ide.eclipse.core.model.AbstractSourceModelElement;
 import org.springframework.ide.eclipse.core.model.IModelElement;
@@ -48,6 +47,7 @@ import org.springframework.ide.eclipse.core.model.validation.IValidationRule;
 import org.springframework.ide.eclipse.core.model.validation.ValidationProblemAttribute;
 import org.springframework.ide.eclipse.core.model.xml.XmlSourceLocation;
 import org.springframework.util.StringUtils;
+import org.springsource.ide.eclipse.commons.core.SpringCoreUtils;
 
 /**
  * Validates a given {@link IBean}'s or {@link IBeansValueHolder}'s bean reference(s).

--- a/plugins/org.springframework.ide.eclipse.beans.core/src/org/springframework/ide/eclipse/beans/core/internal/model/validation/rules/NamespaceElementsRule.java
+++ b/plugins/org.springframework.ide.eclipse.beans.core/src/org/springframework/ide/eclipse/beans/core/internal/model/validation/rules/NamespaceElementsRule.java
@@ -30,14 +30,14 @@ import org.springframework.ide.eclipse.beans.core.model.validation.IXmlValidatio
 import org.springframework.ide.eclipse.beans.core.namespaces.NamespaceUtils;
 import org.springframework.ide.eclipse.beans.core.namespaces.ToolAnnotationUtils.ToolAnnotationData;
 import org.springframework.ide.eclipse.core.SpringCore;
-import org.springframework.ide.eclipse.core.SpringCoreUtils;
 import org.springframework.ide.eclipse.core.java.Introspector;
-import org.springframework.ide.eclipse.core.java.JdtUtils;
 import org.springframework.ide.eclipse.core.java.Introspector.Public;
 import org.springframework.ide.eclipse.core.java.Introspector.Static;
+import org.springframework.ide.eclipse.core.java.JdtUtils;
 import org.springframework.ide.eclipse.core.model.validation.IValidationRule;
 import org.springframework.ide.eclipse.core.model.validation.ValidationProblemAttribute;
 import org.springframework.util.StringUtils;
+import org.springsource.ide.eclipse.commons.core.SpringCoreUtils;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;

--- a/plugins/org.springframework.ide.eclipse.core/src/org/springframework/ide/eclipse/core/java/Introspector.java
+++ b/plugins/org.springframework.ide.eclipse.core/src/org/springframework/ide/eclipse/core/java/Introspector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2013 Spring IDE Developers
+ * Copyright (c) 2007, 2014 Spring IDE Developers
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -239,21 +239,14 @@ public final class Introspector {
 	 */
 	public static IMethod findMethod(IType type, String methodName, int argCount, Public publics, Static statics)
 			throws JavaModelException {
-		if (type != null && type.isInterface()) {
-			IMethod method = findMethodOnType(type, methodName, argCount, publics, statics);
+		for (IType itrType = type; itrType != null; itrType = getSuperType(itrType)) {
+			IMethod method = findMethodOnType(itrType, methodName, argCount, publics, statics);
 			if (method != null) {
 				return method;
-			}
-			for (IType interfaceType : getAllImplementedInterfaces(type)) {
-				return findMethod(interfaceType, methodName, argCount, publics, statics);
 			}
 		}
-		while (type != null) {
-			IMethod method = findMethodOnType(type, methodName, argCount, publics, statics);
-			if (method != null) {
-				return method;
-			}
-			type = getSuperType(type);
+		for (IType interfaceType : getAllImplementedInterfaces(type)) {
+			return findMethod(interfaceType, methodName, argCount, publics, statics);
 		}
 		return null;
 	}


### PR DESCRIPTION
Fix is in Introspector and BeanClassRule. The rest is the fix imports for various classes to eliminate warning for the deprecated moved utility class.
Martin, can you take a look at this PR please? Wonder if you would agree on the warning for non-abstract beans mapped to abstract classes (we already have a warning for beans mapped to interfaces)
