### PR TITLE
Support for "project-aware" protocol URLs to avoid JAR locking on Windows Platform

### DIFF
--- a/plugins/org.springframework.ide.eclipse.beans.core.tests/META-INF/MANIFEST.MF
+++ b/plugins/org.springframework.ide.eclipse.beans.core.tests/META-INF/MANIFEST.MF
@@ -24,7 +24,8 @@ Require-Bundle: org.eclipse.core.runtime,
  javax.persistence,
  org.hamcrest.library;bundle-version="[1.0.0,2.0.0)",
  org.hamcrest.core;bundle-version="[1.0.0,2.0.0)",
- org.springframework.orm
+ org.springframework.orm,
+ org.springsource.ide.eclipse.commons.frameworks.test.util
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-Vendor: Spring IDE Developers

--- a/plugins/org.springframework.ide.eclipse.beans.core.tests/src/org/springframework/ide/eclipse/beans/core/model/tests/BeansProjectAutoConfigTest.java
+++ b/plugins/org.springframework.ide.eclipse.beans.core.tests/src/org/springframework/ide/eclipse/beans/core/model/tests/BeansProjectAutoConfigTest.java
@@ -35,6 +35,7 @@ import org.springframework.ide.eclipse.beans.core.model.IBeansConfigSet;
 import org.springframework.ide.eclipse.beans.core.model.locate.BeansConfigLocatorDefinition;
 import org.springframework.ide.eclipse.beans.core.model.locate.BeansConfigLocatorFactory;
 import org.springframework.ide.eclipse.core.SpringCore;
+import org.springsource.ide.eclipse.commons.frameworks.test.util.ACondition;
 import org.springsource.ide.eclipse.commons.tests.util.StsTestUtil;
 
 /**
@@ -188,6 +189,13 @@ public class BeansProjectAutoConfigTest {
 			configs = beansProject.getConfigs();
 			assertEquals(0, configs.size());
 		} finally {
+			new ACondition("Wait for Jobs") {
+				@Override
+				public boolean test() throws Exception {
+					assertJobManagerIdle();
+					return true;
+				}
+			}.waitFor(3 * 60 * 1000);
 			project.delete(true, null);
 		}
 	}
@@ -230,6 +238,13 @@ public class BeansProjectAutoConfigTest {
 			Set<String> autoConfigSetNames = beansProject.getAutoConfigSetNames();
 			assertEquals(0, autoConfigSetNames.size());
 		} finally {
+			new ACondition("Wait for Jobs") {
+				@Override
+				public boolean test() throws Exception {
+					assertJobManagerIdle();
+					return true;
+				}
+			}.waitFor(3 * 60 * 1000);
 			project.delete(true, null);
 		}
 
@@ -260,6 +275,13 @@ public class BeansProjectAutoConfigTest {
 			
 			assertTrue(autoConfigs.contains("java:org.test.advanced.SpringBootConfigClass"));
 		} finally {
+			new ACondition("Wait for Jobs") {
+				@Override
+				public boolean test() throws Exception {
+					assertJobManagerIdle();
+					return true;
+				}
+			}.waitFor(3 * 60 * 1000);
 			project.delete(true, null);
 		}
 
@@ -317,6 +339,13 @@ public class BeansProjectAutoConfigTest {
 			autoConfigs = beansProject.getAutoConfigNames();
 			assertEquals(1, autoConfigs.size());
 		} finally {
+			new ACondition("Wait for Jobs") {
+				@Override
+				public boolean test() throws Exception {
+					assertJobManagerIdle();
+					return true;
+				}
+			}.waitFor(3 * 60 * 1000);
 			project.delete(true, null);
 		}
 	}
@@ -347,6 +376,13 @@ public class BeansProjectAutoConfigTest {
 			assertEquals(1, configNamesInSet.size());
 			assertEquals("WebContent/WEB-INF/spring/root-context.xml", configNamesInSet.iterator().next());
 		} finally {
+			new ACondition("Wait for Jobs") {
+				@Override
+				public boolean test() throws Exception {
+					assertJobManagerIdle();
+					return true;
+				}
+			}.waitFor(3 * 60 * 1000);
 			project.delete(true, null);
 		}
 	}
@@ -388,6 +424,13 @@ public class BeansProjectAutoConfigTest {
 			Set<String> autoConfigSetNames = beansProject.getAutoConfigSetNames();
 			assertEquals(0, autoConfigSetNames.size());
 		} finally {
+			new ACondition("Wait for Jobs") {
+				@Override
+				public boolean test() throws Exception {
+					assertJobManagerIdle();
+					return true;
+				}
+			}.waitFor(3 * 60 * 1000);
 			project.delete(true, null);
 		}
 	}

--- a/plugins/org.springframework.ide.eclipse.beans.core/META-INF/MANIFEST.MF
+++ b/plugins/org.springframework.ide.eclipse.beans.core/META-INF/MANIFEST.MF
@@ -117,4 +117,5 @@ Export-Package: org.springframework.ide.eclipse.beans.core,
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.apache.commons.logging,
- org.eclipse.jface
+ org.eclipse.jface,
+ org.eclipse.osgi

--- a/plugins/org.springframework.ide.eclipse.beans.core/plugin.xml
+++ b/plugins/org.springframework.ide.eclipse.beans.core/plugin.xml
@@ -226,18 +226,20 @@
           </projectNature> -->
        </resolverExtension>
     </extension>
-   
+
+<!--   
     <extension
           point="org.eclipse.wst.common.uriresolver.resolverExtensions">
        <resolverExtension
              class="org.springframework.ide.eclipse.beans.core.internal.model.namespaces.ProjectClasspathExtensibleUriPhysicalLocationResolver"
              priority="high"
              stage="physical">
-<!--          <projectNature
+         <projectNature
                 value="org.springframework.ide.eclipse.core.springnature">
-          </projectNature> -->
+          </projectNature>
        </resolverExtension>
     </extension>
+-->
     <extension
           point="org.springframework.ide.eclipse.beans.core.beansconfiglocators">
        <beansConfigLocator

--- a/plugins/org.springframework.ide.eclipse.beans.core/src/org/springframework/ide/eclipse/beans/core/ProjectAwareUrlStreamHandlerService.java
+++ b/plugins/org.springframework.ide.eclipse.beans.core/src/org/springframework/ide/eclipse/beans/core/ProjectAwareUrlStreamHandlerService.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2014 Pivotal Software Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Spring IDE Developers - initial API and implementation
+ *******************************************************************************/
+package org.springframework.ide.eclipse.beans.core;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLConnection;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.osgi.service.url.AbstractURLStreamHandlerService;
+import org.springframework.ide.eclipse.core.java.JdtUtils;
+
+/**
+ * Support for "project-aware" URL protocol. The protocol is for resources
+ * within JARs. The JARs are located within a Spring project.
+ * 
+ * @author Alex Boyko
+ *
+ */
+public class ProjectAwareUrlStreamHandlerService extends
+		AbstractURLStreamHandlerService {
+	
+	public static final String PROJECT_AWARE_PROTOCOL = "project-aware";
+	public static final String PROJECT_AWARE_PROTOCOL_HEADER = PROJECT_AWARE_PROTOCOL + "://";
+
+	@Override
+	public URLConnection openConnection(URL u) throws IOException {
+		String systemId = u.toString();
+		String nameAndLocation = systemId.substring(PROJECT_AWARE_PROTOCOL_HEADER.length());
+		String projectName = nameAndLocation.substring(0, nameAndLocation.indexOf('/'));
+		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(projectName);
+		String resourceId = nameAndLocation.substring(nameAndLocation.indexOf('/') + 1);
+		ClassLoader cl = JdtUtils.getClassLoader(project, null);
+		URL resource = cl.getResource(resourceId);
+		if (resource != null) {
+			return resource.openConnection();
+		}
+		return null;
+	}
+	
+	/**
+	 * Creates a string representation of a project-aware protocol URL from
+	 * project name and a resource name
+	 * 
+	 * @param projectName
+	 *            spring project name
+	 * @param resourceName
+	 *            class loader resource name
+	 * @return URL string
+	 */
+	public static String createProjectAwareUrl(String projectName, String resourceName) {
+		StringBuilder sb = new StringBuilder();
+		sb.append(ProjectAwareUrlStreamHandlerService.PROJECT_AWARE_PROTOCOL_HEADER);
+		sb.append(projectName);
+		sb.append('/');
+		sb.append(resourceName);
+		return sb.toString();
+	}
+
+}

--- a/plugins/org.springframework.ide.eclipse.beans.core/src/org/springframework/ide/eclipse/beans/core/internal/model/namespaces/ProjectClasspathExtensibleUriPhysicalLocationResolver.java
+++ b/plugins/org.springframework.ide.eclipse.beans.core/src/org/springframework/ide/eclipse/beans/core/internal/model/namespaces/ProjectClasspathExtensibleUriPhysicalLocationResolver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 Spring IDE Developers
+ * Copyright (c) 2013, 2014 Spring IDE Developers
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,7 @@ package org.springframework.ide.eclipse.beans.core.internal.model.namespaces;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.wst.common.uriresolver.internal.provisional.URIResolverExtension;
+import org.springframework.ide.eclipse.beans.core.ProjectAwareUrlStreamHandlerService;
 
 /**
  * {@link URIResolverExtension} resolves the physical location of schema files on the project classpath using the
@@ -27,8 +28,8 @@ public class ProjectClasspathExtensibleUriPhysicalLocationResolver implements UR
 	}
 
 	public String resolve(IFile file, String baseLocation, String publicId, String systemId) {
-		if (systemId != null && systemId.startsWith(ProjectClasspathExtensibleUriResolver.PROJECT_AWARE_PROTOCOL)) {
-			String nameAndLocation = systemId.substring(ProjectClasspathExtensibleUriResolver.PROJECT_AWARE_PROTOCOL.length());
+		if (systemId != null && systemId.startsWith(ProjectAwareUrlStreamHandlerService.PROJECT_AWARE_PROTOCOL_HEADER)) {
+			String nameAndLocation = systemId.substring(ProjectAwareUrlStreamHandlerService.PROJECT_AWARE_PROTOCOL_HEADER.length());
 			String realSystemId = nameAndLocation.substring(nameAndLocation.indexOf('/') + 1);
 			return realSystemId;
 		}

--- a/plugins/org.springframework.ide.eclipse.beans.core/src/org/springframework/ide/eclipse/beans/core/internal/model/namespaces/ProjectClasspathExtensibleUriResolver.java
+++ b/plugins/org.springframework.ide.eclipse.beans.core/src/org/springframework/ide/eclipse/beans/core/internal/model/namespaces/ProjectClasspathExtensibleUriResolver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2013 Spring IDE Developers
+ * Copyright (c) 2010, 2014 Spring IDE Developers
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -38,6 +38,7 @@ import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.wst.common.uriresolver.internal.provisional.URIResolverExtension;
 import org.springframework.ide.eclipse.beans.core.BeansCorePlugin;
+import org.springframework.ide.eclipse.beans.core.ProjectAwareUrlStreamHandlerService;
 import org.springframework.ide.eclipse.beans.core.internal.model.namespaces.DocumentAccessor.SchemaLocations;
 import org.springframework.ide.eclipse.beans.core.model.IBeansProject;
 import org.springframework.ide.eclipse.beans.core.namespaces.NamespaceUtils;
@@ -61,8 +62,6 @@ public class ProjectClasspathExtensibleUriResolver implements
 	private static final String KEY_DISABLE_CACHING_PREFERENCE = BeansCorePlugin.PLUGIN_ID + "."
 			+ BeansCorePlugin.DISABLE_CACHING_FOR_NAMESPACE_LOADING_ID;
 	
-	public static final String PROJECT_AWARE_PROTOCOL = "project-aware://";
-
 //	private static Map<IProject, ProjectClasspathUriResolver> projectResolvers = new ConcurrentHashMap<IProject, ProjectClasspathUriResolver>();
 	private static ConcurrentMap<IProject, Future<ProjectClasspathUriResolver>> projectResolvers = new ConcurrentHashMap<IProject, Future<ProjectClasspathUriResolver>>();
 
@@ -87,9 +86,11 @@ public class ProjectClasspathExtensibleUriResolver implements
 		IProject project = null;
 		if (file != null) {
 			project = getBestMatchingProject(file);
-		}
-		else if (baseLocation != null && baseLocation.startsWith(PROJECT_AWARE_PROTOCOL)) {
-			String nameAndLocation = baseLocation.substring(PROJECT_AWARE_PROTOCOL.length());
+		} else if (baseLocation != null 
+				&& baseLocation.startsWith(ProjectAwareUrlStreamHandlerService.PROJECT_AWARE_PROTOCOL_HEADER)) {
+			String nameAndLocation = baseLocation
+					.substring(ProjectAwareUrlStreamHandlerService.PROJECT_AWARE_PROTOCOL_HEADER
+							.length());
 			String projectName = nameAndLocation.substring(0, nameAndLocation.indexOf('/'));
 			project = ResourcesPlugin.getWorkspace().getRoot().getProject(projectName);
 		}
@@ -111,7 +112,7 @@ public class ProjectClasspathExtensibleUriResolver implements
 		if (resolver != null) {
 			String resolved = resolver.resolveOnClasspath(publicId, systemId);
 			if (resolved != null) {
-				resolved = PROJECT_AWARE_PROTOCOL + project.getName() + "/" + resolved;
+				resolved = ProjectAwareUrlStreamHandlerService.createProjectAwareUrl(project.getName(), resolved);
 			}
 			return resolved;
 		}

--- a/plugins/org.springframework.ide.eclipse.beans.core/src/org/springframework/ide/eclipse/beans/core/internal/model/namespaces/ProjectClasspathUriResolver.java
+++ b/plugins/org.springframework.ide.eclipse.beans.core/src/org/springframework/ide/eclipse/beans/core/internal/model/namespaces/ProjectClasspathUriResolver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Spring IDE Developers
+ * Copyright (c) 2011, 2014 Spring IDE Developers
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -22,6 +22,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.eclipse.core.resources.IProject;
 import org.springframework.core.io.support.PropertiesLoaderUtils;
 import org.springframework.ide.eclipse.beans.core.BeansCorePlugin;
+import org.springframework.ide.eclipse.beans.core.ProjectAwareUrlStreamHandlerService;
 import org.springframework.ide.eclipse.beans.core.namespaces.NamespaceUtils;
 import org.springframework.ide.eclipse.core.java.JdtUtils;
 import org.springframework.util.CollectionUtils;
@@ -152,7 +153,9 @@ public class ProjectClasspathUriResolver {
 		}
 
 		try {
-			URL url = new URI(resolvedPath).toURL();
+			URL url = new URI(
+					ProjectAwareUrlStreamHandlerService.createProjectAwareUrl(
+							project.getName(), resolvedPath)).toURL();
 			return TargetNamespaceScanner.getTargetNamespace(url);
 		} catch (IOException e) {
 			BeansCorePlugin.log(e);
@@ -193,7 +196,7 @@ public class ProjectClasspathUriResolver {
 			url = cls.getResource(xsdPath);
 		}
 
-		return url != null ? url.toString() : null;
+		return url == null ? null : xsdPath;
 	}
 
 }


### PR DESCRIPTION
Changes:
Instead of caching full resource URLs (JAR protocol) only the resource names are cached (the ones that can be used with Class Loader to get the URL)
Removed the physical URI resolver and added the OSGi URL Stream Hanlder service to handle "project-aware" protocol URLs. This should resolves 2 issues: support non-locking JAR accessing mechanism on Win and eliminate the physical URI resolver
Bean Core JUnits are passing on Mac and Win7 with this fix.
