### PR TITLE
Updating nightly-distributions URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
   If you want to live on the bleading egde, you can also install always up-to-date continuous
   integration buids from this update site:
 
-  http://dist.springframework.org/snapshot/IDE/nightly/
+  http://dist.springsource.com/snapshot/STS/nightly-distributions.html
 
   But take care, those builds could be broken from time to time and might contain non-ship-ready
   features that might never appear in the milestone or release builds.


### PR DESCRIPTION
I'm trying to access to http://dist.springframework.org/snapshot/IDE/nightly/ and I'm not able to show nightly deployments URLs

I've just updated URL above on README.md  with the following:

http://dist.springsource.com/snapshot/STS/nightly-distributions.html

That works for me.

Regards,

