### PR TITLE
Adding 'Roo Addon Suite' as new project type on Spring Roo project wizard

### DIFF
--- a/plugins/org.springframework.ide.eclipse.roo.ui/src/org/springframework/ide/eclipse/roo/ui/internal/wizard/NewRooProjectWizard.java
+++ b/plugins/org.springframework.ide.eclipse.roo.ui/src/org/springframework/ide/eclipse/roo/ui/internal/wizard/NewRooProjectWizard.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2012 - 2013 GoPivotal, Inc.
+ *  Copyright (c) 2012 - 2015 GoPivotal, Inc.
  *  All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0
  *  which accompanies this distribution, and is available at
@@ -7,6 +7,7 @@
  *
  *  Contributors:
  *      GoPivotal, Inc. - initial API and implementation
+ *      DISID Corporation, S.L - Spring Roo maintainer
  *******************************************************************************/
 package org.springframework.ide.eclipse.roo.ui.internal.wizard;
 
@@ -49,6 +50,7 @@ import org.springsource.ide.eclipse.commons.core.SpringCoreUtils;
 /**
  * @author Christian Dupuis
  * @author Leo Dos Santos
+ * @author Juan Carlos García
  * @since 2.2.0
  */
 @SuppressWarnings("restriction")
@@ -171,7 +173,11 @@ public class NewRooProjectWizard extends NewElementWizard implements INewWizard 
 							builder.append(" --packaging ").append(packagingProvider);
 						}
 					}
-					else {
+					else if(type == ProjectType.ADDON_SUITE){
+						builder.append(" --projectName ").append(projectPage.getProjectName());
+						builder.append(" --description \"").append(projectPage.getDescription()).append("\"");
+
+					}else{
 						builder.append(" --description \"").append(projectPage.getDescription()).append("\"");
 					}
 
@@ -316,7 +322,7 @@ public class NewRooProjectWizard extends NewElementWizard implements INewWizard 
 
 	public enum ProjectType {
 
-		PROJECT, ADDON_SIMPLE, ADDON_ADVANCED;
+		PROJECT, ADDON_SIMPLE, ADDON_ADVANCED, ADDON_SUITE;
 
 		public String getCommand() {
 			if (this == PROJECT) {
@@ -327,6 +333,9 @@ public class NewRooProjectWizard extends NewElementWizard implements INewWizard 
 			}
 			else if (this == ADDON_ADVANCED) {
 				return "addon create advanced";
+				
+			}else if (this == ADDON_SUITE){
+				return "addon create suite";
 			}
 			return "";
 		}
@@ -340,6 +349,9 @@ public class NewRooProjectWizard extends NewElementWizard implements INewWizard 
 			}
 			else if (this == ADDON_ADVANCED) {
 				return "Add-on advanced";
+				
+			}else if (this == ADDON_SUITE){
+				return "Roo Add-on Suite";
 			}
 			return null;
 		}
@@ -353,6 +365,9 @@ public class NewRooProjectWizard extends NewElementWizard implements INewWizard 
 			}
 			else if (display.equals("Add-on advanced")) {
 				return ADDON_ADVANCED;
+				
+			}else if (display.equals("Roo Add-on Suite")){
+				return ADDON_SUITE;
 			}
 			return null;
 		}

--- a/plugins/org.springframework.ide.eclipse.roo.ui/src/org/springframework/ide/eclipse/roo/ui/internal/wizard/NewRooProjectWizardPageOne.java
+++ b/plugins/org.springframework.ide.eclipse.roo.ui/src/org/springframework/ide/eclipse/roo/ui/internal/wizard/NewRooProjectWizardPageOne.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2012 - 2013 GoPivotal, Inc.
+ *  Copyright (c) 2012 - 2015 GoPivotal, Inc.
  *  All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0
  *  which accompanies this distribution, and is available at
@@ -7,6 +7,7 @@
  *
  *  Contributors:
  *      GoPivotal, Inc. - initial API and implementation
+ *      DISID Corporation, S.L - Spring Roo maintainer
  *******************************************************************************/
 package org.springframework.ide.eclipse.roo.ui.internal.wizard;
 
@@ -49,6 +50,7 @@ import org.eclipse.jdt.internal.ui.wizards.dialogfields.StringDialogField;
 import org.eclipse.jdt.ui.JavaUI;
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.ITreeSelection;
@@ -89,6 +91,7 @@ import org.springframework.ide.eclipse.roo.ui.internal.wizard.NewRooProjectWizar
  * @author Steffen Pingel
  * @author Terry Denney
  * @author Leo Dos Santos
+ * @author Juan Carlos García
  */
 @SuppressWarnings("restriction")
 public class NewRooProjectWizardPageOne extends WizardPage {
@@ -468,6 +471,27 @@ public class NewRooProjectWizardPageOne extends WizardPage {
 					c.setEnabled(enableFlag);
 				}
 			}
+			
+			
+			// Checks if Spring Roo 2.0+ version is selected
+			String version = null;
+			if (useDefaultRooInstall()) {
+				version = RooCoreActivator.getDefault().getInstallManager().getDefaultRooInstall().getVersion();
+			}
+			else {
+				String installName = getRooInstallName();
+				if (installName != null) {
+					version = RooCoreActivator.getDefault().getInstallManager().getRooInstall(installName).getVersion();
+				}
+			}
+			
+			// Roo Addon Suite generation only is available on Spring Roo 2.0+ version
+			if(!version.startsWith("2") && getProjectType().equals(ProjectType.ADDON_SUITE)){
+				MessageDialog.openInformation(getShell(), "Spring Roo Alert", "You are trying to use a functionality that is only available on Spring Roo 2.0+ versions."
+						+ " Please, install an Spring Roo 2.0+ distribution to continue.");
+				fNameGroup.fTemplateField.selectItem(0);
+			}
+			
 		}
 
 		public void update(Observable o, Object arg) {


### PR DESCRIPTION
I've just implemented a new command to generate a basic Roo Addon Suite. 

 https://jira.spring.io/browse/ROO-3620

Spring Roo STS Plugin has support to generate *projects*, *simple addons* and *advanced addons*... so is necessary that every developer will be able to generate his own *Roo Addon Suite* using STS.

Roo Addon Suite generator will be available only if some Spring Roo 2.0+ distribution is installed on STS.

