### PR TITLE
Prevent deploy of eclipse roo shell bundle with version 1.2.0 when Spring Roo 2.x is used

### DIFF
--- a/plugins/org.springframework.ide.eclipse.roo.core/src/org/springframework/roo/shell/eclipse/AutoProcessor.java
+++ b/plugins/org.springframework.ide.eclipse.roo.core/src/org/springframework/roo/shell/eclipse/AutoProcessor.java
@@ -295,7 +295,7 @@ public class AutoProcessor {
 				return matchesVersion("[1.1.0, 1.2.0)", rooVersion);
 			}
 			if (filename.startsWith("org.springframework.roo.shell.eclipse-1.2.0")) {
-				return matchesVersion("1.2.0", rooVersion);
+				return matchesVersion("[1.2.0, 1.4.0)", rooVersion);
 			}
 			if (filename.startsWith("org.springframework.roo.shell.eclipse-2.0.0")) {
 				return matchesVersion("2.0.0", rooVersion);


### PR DESCRIPTION
Related with the following Spring Roo error:

https://jira.spring.io/browse/ROO-3664

Prevent deploy of eclipse roo shell bundle with version 1.2.0 when Spring Roo 2.x is used updating version range on AutoProcessor.java