### PR TITLE
Experimental change that makes both stop button and

### DIFF
--- a/plugins/org.springframework.ide.eclipse.boot.dash/src/org/springframework/ide/eclipse/boot/dash/model/BootProjectDashElement.java
+++ b/plugins/org.springframework.ide.eclipse.boot.dash/src/org/springframework/ide/eclipse/boot/dash/model/BootProjectDashElement.java
@@ -12,6 +12,7 @@ package org.springframework.ide.eclipse.boot.dash.model;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -25,7 +26,6 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.runtime.jobs.ISchedulingRule;
 import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
@@ -162,6 +162,7 @@ public class BootProjectDashElement extends WrappingBootDashElement<IProject> im
 	}
 
 	protected void launch(final String runMode, final ILaunchConfiguration conf) {
+		setPreferredConfig(conf);
 		Display.getDefault().syncExec(new Runnable() {
 			public void run() {
 				DebugUITools.launch(conf, runMode);
@@ -213,7 +214,7 @@ public class BootProjectDashElement extends WrappingBootDashElement<IProject> im
 		debug("Stopping: "+this+" "+(sync?"...":""));
 		final ResolvableFuture<Void> done = sync?new ResolvableFuture<Void>():null;
 		try {
-			List<ILaunch> launches = LaunchUtil.getLaunches(getProject());
+			List<ILaunch> launches = getLaunches();
 			if (sync) {
 				LaunchUtils.whenTerminated(launches, new Runnable() {
 					public void run() {
@@ -238,6 +239,14 @@ public class BootProjectDashElement extends WrappingBootDashElement<IProject> im
 			done.get(6, TimeUnit.SECONDS);
 			debug("Stopping: "+this+" "+"DONE");
 		}
+	}
+
+	private List<ILaunch> getLaunches() {
+		ILaunchConfiguration conf = getActiveConfig();
+		if (conf!=null) {
+			return LaunchUtil.getLaunches(conf);
+		}
+		return Collections.emptyList();
 	}
 
 	public static void debug(String string) {

--- a/plugins/org.springframework.ide.eclipse.boot.dash/src/org/springframework/ide/eclipse/boot/dash/util/LaunchUtil.java
+++ b/plugins/org.springframework.ide.eclipse.boot.dash/src/org/springframework/ide/eclipse/boot/dash/util/LaunchUtil.java
@@ -49,5 +49,17 @@ public class LaunchUtil {
 		return Collections.emptyList();
 	}
 
-
+	public static List<ILaunch> getLaunches(ILaunchConfiguration conf) {
+		ILaunch[] allLaunches = DebugPlugin.getDefault().getLaunchManager().getLaunches();
+		if (allLaunches!=null && allLaunches.length>0) {
+			List<ILaunch> launches = new ArrayList<ILaunch>();
+			for (ILaunch launch : allLaunches) {
+				if (conf.equals(launch.getLaunchConfiguration())) {
+					launches.add(launch);
+				}
+			}
+			return launches;
+		}
+		return Collections.emptyList();
+	}
 }

--- a/plugins/org.springframework.ide.eclipse.boot.dash/src/org/springframework/ide/eclipse/boot/dash/util/ProjectRunStateTracker.java
+++ b/plugins/org.springframework.ide.eclipse.boot.dash/src/org/springframework/ide/eclipse/boot/dash/util/ProjectRunStateTracker.java
@@ -98,7 +98,7 @@ public class ProjectRunStateTracker extends ProcessListenerAdapter {
 		return states;
 	}
 
-	private boolean isInteresting(ILaunch l) {
+	protected boolean isInteresting(ILaunch l) {
 		try {
 			ILaunchConfiguration conf = l.getLaunchConfiguration();
 			if (conf!=null) {

--- a/plugins/org.springframework.ide.eclipse.boot.launch/src/org/springframework/ide/eclipse/boot/launch/util/BootLaunchUtils.java
+++ b/plugins/org.springframework.ide.eclipse.boot.launch/src/org/springframework/ide/eclipse/boot/launch/util/BootLaunchUtils.java
@@ -12,13 +12,20 @@ package org.springframework.ide.eclipse.boot.launch.util;
 
 import static org.springsource.ide.eclipse.commons.ui.launch.LaunchUtils.whenTerminated;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.debug.core.DebugException;
+import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.ILaunchConfigurationType;
+import org.eclipse.debug.core.ILaunchManager;
 import org.springframework.ide.eclipse.boot.core.BootActivator;
 import org.springframework.ide.eclipse.boot.launch.BootLaunchConfigurationDelegate;
 
@@ -73,6 +80,31 @@ public class BootLaunchUtils {
 //		} catch (Exception e) {
 //			BootActivator.log(e);
 //		}
+	}
+
+	/**
+	 * Get Boot launch configs associated with a given project.
+	 */
+	public static List<ILaunchConfiguration> getLaunchConfigs(IProject project) {
+		try {
+			if (project!=null) {
+				ILaunchManager mgr = DebugPlugin.getDefault().getLaunchManager();
+				ILaunchConfigurationType type = mgr.getLaunchConfigurationType(BootLaunchConfigurationDelegate.TYPE_ID);
+				ILaunchConfiguration[] allConfs = mgr.getLaunchConfigurations(type);
+				if (allConfs!=null && allConfs.length>0) {
+					ArrayList<ILaunchConfiguration> confs = new ArrayList<>(allConfs.length);
+					for (ILaunchConfiguration c : allConfs) {
+						if (project.equals(BootLaunchConfigurationDelegate.getProject(c))) {
+							confs.add(c);
+						}
+					}
+					return confs;
+				}
+			}
+		} catch (Exception e) {
+			BootActivator.log(e);
+		}
+		return Collections.emptyList();
 	}
 
 }


### PR DESCRIPTION
runstate tracker for local apps based only on processes
associated with the 'blessed' launch config.

Note: not sure yet we want to merge this. Just creating this PR so I can point to it in this discussion in the tracker: https://www.pivotaltracker.com/story/show/104726470
