### PR TITLE
ROO-3730: Generate Multimodule projects from STS Spring Roo Plugin

### DIFF
--- a/plugins/org.springframework.ide.eclipse.roo.ui/plugin.xml
+++ b/plugins/org.springframework.ide.eclipse.roo.ui/plugin.xml
@@ -2,14 +2,15 @@
 <?eclipse version="3.2"?>
 <!--
 /*******************************************************************************
- * Copyright (c) 2012, 2013 Spring IDE Developers
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- * 
- * Contributors:
- *     Spring IDE Developers - initial API and implementation
+ *  Copyright (c) 2012 - 2016 GoPivotal, Inc.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *      GoPivotal, Inc. - initial API and implementation
+ *      DISID Corporation, S.L - Spring Roo maintainer
  *******************************************************************************/
  -->
 <plugin>
@@ -226,6 +227,7 @@
             project="true">
       </wizard>
    </extension>
+   
    
    <extension point="org.eclipse.ui.perspectiveExtensions">
 		<perspectiveExtension 

--- a/plugins/org.springframework.ide.eclipse.roo.ui/src/org/springframework/ide/eclipse/roo/ui/internal/RooUiUtil.java
+++ b/plugins/org.springframework.ide.eclipse.roo.ui/src/org/springframework/ide/eclipse/roo/ui/internal/RooUiUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2012 VMware, Inc.
+ *  Copyright (c) 2012, 2016 GoPivotal, Inc.
  *  All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0
  *  which accompanies this distribution, and is available at
@@ -7,15 +7,19 @@
  *
  *  Contributors:
  *      VMware, Inc. - initial API and implementation
+ *      DISID Corporation, S.L - Spring Roo maintainer
  *******************************************************************************/
 package org.springframework.ide.eclipse.roo.ui.internal;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.dialogs.PreferencesUtil;
 import org.osgi.framework.Version;
 import org.springframework.ide.eclipse.roo.core.RooCoreActivator;
 import org.springframework.ide.eclipse.roo.core.internal.model.DefaultRooInstall;
@@ -27,6 +31,7 @@ import org.springsource.ide.eclipse.commons.core.SpringCoreUtils;
  * 
  * @author Steffen Pingel
  * @author Leo Dos Santos
+ * @author Juan Carlos García
  */
 public class RooUiUtil {
 
@@ -58,6 +63,11 @@ public class RooUiUtil {
 			}
 		}
 		return false;
+	}
+	
+	public static void openPreferences(Shell shell) {
+		String id = "com.springsource.sts.roo.ui.preferencePage";
+		PreferencesUtil.createPreferenceDialogOn(shell, id, new String[] { id }, Collections.EMPTY_MAP).open();
 	}
 	
 }

--- a/plugins/org.springframework.ide.eclipse.roo.ui/src/org/springframework/ide/eclipse/roo/ui/internal/wizard/NewRooProjectWizard.java
+++ b/plugins/org.springframework.ide.eclipse.roo.ui/src/org/springframework/ide/eclipse/roo/ui/internal/wizard/NewRooProjectWizard.java
@@ -378,6 +378,12 @@ public class NewRooProjectWizard extends NewElementWizard implements INewWizard 
 			if (display.equals("Standard")) {
 				return PROJECT;
 			}
+			else if (display.equals("Multimodule Standard")) {
+				return MULTIMODULE_STANDARD;
+			}
+			else if (display.equals("Multimodule Basic")) {
+				return MULTIMODULE_BASIC;
+			}
 			else if (display.equals("Add-on simple")) {
 				return ADDON_SIMPLE;
 			}

--- a/plugins/org.springframework.ide.eclipse.roo.ui/src/org/springframework/ide/eclipse/roo/ui/internal/wizard/NewRooProjectWizard.java
+++ b/plugins/org.springframework.ide.eclipse.roo.ui/src/org/springframework/ide/eclipse/roo/ui/internal/wizard/NewRooProjectWizard.java
@@ -65,11 +65,13 @@ public class NewRooProjectWizard extends NewElementWizard implements INewWizard 
 		ROO_JAVA_VERSION_MAPPING.put("1.5", "5");
 		ROO_JAVA_VERSION_MAPPING.put("1.6", "6");
 		ROO_JAVA_VERSION_MAPPING.put("1.7", "7");
+		ROO_JAVA_VERSION_MAPPING.put("1.8", "8");
 
 		FACET_JAVA_VERSION_MAPPING = new HashMap<String, String>();
 		FACET_JAVA_VERSION_MAPPING.put("1.5", "5.0");
 		FACET_JAVA_VERSION_MAPPING.put("1.6", "6.0");
 		FACET_JAVA_VERSION_MAPPING.put("1.7", "7.0");
+		FACET_JAVA_VERSION_MAPPING.put("1.8", "8.0");
 	}
 
 	private static final String CLASSPATH_FILE = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
@@ -138,7 +140,7 @@ public class NewRooProjectWizard extends NewElementWizard implements INewWizard 
 					String javaVersion = JavaCore.getOption("org.eclipse.jdt.core.compiler.compliance");
 					String rooJavaVersion = (ROO_JAVA_VERSION_MAPPING.containsKey(javaVersion) ? ROO_JAVA_VERSION_MAPPING
 							.get(javaVersion)
-							: "6");
+							: "8");
 
 					// Create Roo project by launching Roo and invoking the
 					// create project command
@@ -172,6 +174,16 @@ public class NewRooProjectWizard extends NewElementWizard implements INewWizard 
 						if (RooUiUtil.isRoo120OrGreater(install)) {
 							builder.append(" --packaging ").append(packagingProvider);
 						}
+					}
+					else if(type == ProjectType.MULTIMODULE_STANDARD){
+						builder.append(" --projectName ").append(projectPage.getProjectName());
+						builder.append(" --java ").append(rooJavaVersion);
+						builder.append(" --multimodule STANDARD");
+					}
+					else if(type == ProjectType.MULTIMODULE_BASIC){
+						builder.append(" --projectName ").append(projectPage.getProjectName());
+						builder.append(" --java ").append(rooJavaVersion);
+						builder.append(" --multimodule BASIC");
 					}
 					else if(type == ProjectType.ADDON_SUITE){
 						builder.append(" --projectName ").append(projectPage.getProjectName());
@@ -322,10 +334,10 @@ public class NewRooProjectWizard extends NewElementWizard implements INewWizard 
 
 	public enum ProjectType {
 
-		PROJECT, ADDON_SIMPLE, ADDON_ADVANCED, ADDON_SUITE;
+		PROJECT, MULTIMODULE_STANDARD, MULTIMODULE_BASIC, ADDON_SIMPLE, ADDON_ADVANCED, ADDON_SUITE;
 
 		public String getCommand() {
-			if (this == PROJECT) {
+			if (this == PROJECT || this == MULTIMODULE_STANDARD || this == MULTIMODULE_BASIC) {
 				return "project";
 			}
 			else if (this == ADDON_SIMPLE) {
@@ -343,6 +355,12 @@ public class NewRooProjectWizard extends NewElementWizard implements INewWizard 
 		public String getDisplayString() {
 			if (this == PROJECT) {
 				return "Standard";
+			}
+			else if (this == MULTIMODULE_STANDARD) {
+				return "Multimodule Standard";
+			}
+			else if (this == MULTIMODULE_BASIC) {
+				return "Multimodule Basic";
 			}
 			else if (this == ADDON_SIMPLE) {
 				return "Add-on simple";

--- a/plugins/org.springframework.ide.eclipse.roo.ui/src/org/springframework/ide/eclipse/roo/ui/internal/wizard/NewRooProjectWizard.java
+++ b/plugins/org.springframework.ide.eclipse.roo.ui/src/org/springframework/ide/eclipse/roo/ui/internal/wizard/NewRooProjectWizard.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2012 - 2015 GoPivotal, Inc.
+ *  Copyright (c) 2012 - 2016 GoPivotal, Inc.
  *  All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0
  *  which accompanies this distribution, and is available at
@@ -29,6 +29,7 @@ import org.eclipse.core.runtime.Path;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.internal.ui.wizards.NewElementWizard;
+import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.INewWizard;
 import org.eclipse.ui.PlatformUI;
@@ -88,9 +89,19 @@ public class NewRooProjectWizard extends NewElementWizard implements INewWizard 
 
 	public NewRooProjectWizard() {
 		super();
+		
+		// Check if exists some Spring Roo installation before continue
+		while(RooCoreActivator.getDefault().getInstallManager().getDefaultRooInstall() == null) {
+			MessageDialog.openInformation(getShell(), "Spring Roo Alert",
+					"You are trying to generate an Spring Roo project, but you don't have any Spring Roo distribution installed."
+							+ "Include some Spring Roo distribution before continue.");
+			RooUiUtil.openPreferences(getShell());
+		}
+		
 		setWindowTitle("New Roo Project");
 		setDefaultPageImageDescriptor(RooUiActivator.getImageDescriptor("icons/full/wizban/roo_wizban.png"));
 		setNeedsProgressMonitor(true);
+		
 	}
 
 	@Override

--- a/plugins/org.springframework.ide.eclipse.roo.ui/src/org/springframework/ide/eclipse/roo/ui/internal/wizard/NewRooProjectWizardPageOne.java
+++ b/plugins/org.springframework.ide.eclipse.roo.ui/src/org/springframework/ide/eclipse/roo/ui/internal/wizard/NewRooProjectWizardPageOne.java
@@ -485,12 +485,17 @@ public class NewRooProjectWizardPageOne extends WizardPage {
 				}
 			}
 			
-			// Roo Addon Suite generation only is available on Spring Roo 2.0+ version
-			if(!version.startsWith("2") && getProjectType().equals(ProjectType.ADDON_SUITE)){
+			// Roo Addon Suite generation and multimodule generation 
+			// is only available on Spring Roo 2.0+ version
+			if(!version.startsWith("2") && 
+					(getProjectType().equals(ProjectType.ADDON_SUITE) || 
+							getProjectType().equals(ProjectType.MULTIMODULE_BASIC) || 
+							getProjectType().equals(ProjectType.MULTIMODULE_STANDARD))){
 				MessageDialog.openInformation(getShell(), "Spring Roo Alert", "You are trying to use a functionality that is only available on Spring Roo 2.0+ versions."
 						+ " Please, install an Spring Roo 2.0+ distribution to continue.");
 				fNameGroup.fTemplateField.selectItem(0);
 			}
+			
 			
 		}
 

--- a/plugins/org.springframework.ide.eclipse.roo.ui/src/org/springframework/ide/eclipse/roo/ui/internal/wizard/NewRooProjectWizardPageOne.java
+++ b/plugins/org.springframework.ide.eclipse.roo.ui/src/org/springframework/ide/eclipse/roo/ui/internal/wizard/NewRooProjectWizardPageOne.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2012 - 2015 GoPivotal, Inc.
+ *  Copyright (c) 2012 - 2016 GoPivotal, Inc.
  *  All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0
  *  which accompanies this distribution, and is available at
@@ -57,6 +57,7 @@ import org.eclipse.jface.viewers.ITreeSelection;
 import org.eclipse.jface.viewers.TreePath;
 import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.ScrolledComposite;
 import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.events.SelectionAdapter;
@@ -1000,11 +1001,16 @@ public class NewRooProjectWizardPageOne extends WizardPage {
 	public void createControl(Composite parent) {
 		initializeDialogUnits(parent);
 
-		final Composite composite = new Composite(parent, SWT.NULL);
+		final ScrolledComposite scrolledComposite = new ScrolledComposite(parent, SWT.BORDER | SWT.V_SCROLL);
+		scrolledComposite.setExpandHorizontal(true);
+		scrolledComposite.setExpandVertical(true);
+		scrolledComposite.setAlwaysShowScrollBars(true);
+		
+		Composite composite = new Composite(scrolledComposite, SWT.NULL);
 		composite.setFont(parent.getFont());
 		composite.setLayout(initGridLayout(new GridLayout(1, false), true));
 		composite.setLayoutData(new GridData(GridData.HORIZONTAL_ALIGN_FILL));
-
+		
 		// create UI elements
 		Control nameControl = createNameControl(composite);
 		nameControl.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
@@ -1025,15 +1031,16 @@ public class NewRooProjectWizardPageOne extends WizardPage {
 
 		Control workingSetControl = createWorkingSetControl(composite);
 		workingSetControl.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+		
+		scrolledComposite.setContent(composite);
+		scrolledComposite.setMinSize(composite.computeSize(SWT.DEFAULT, SWT.DEFAULT));
 
 		setControl(composite);
 	}
 
 	protected void setControl(Control newControl) {
 		Dialog.applyDialogFont(newControl);
-
 		PlatformUI.getWorkbench().getHelpSystem().setHelp(newControl, IJavaHelpContextIds.NEW_JAVAPROJECT_WIZARD_PAGE);
-
 		super.setControl(newControl);
 	}
 

--- a/plugins/org.springframework.ide.eclipse.roo.ui/src/org/springframework/ide/eclipse/roo/ui/internal/wizard/NewRooProjectWizardPageOne.java
+++ b/plugins/org.springframework.ide.eclipse.roo.ui/src/org/springframework/ide/eclipse/roo/ui/internal/wizard/NewRooProjectWizardPageOne.java
@@ -151,7 +151,8 @@ public class NewRooProjectWizardPageOne extends WizardPage {
 
 				public void modifyText(ModifyEvent e) {
 					ProjectType type = getProjectType();
-					fdescriptionField.setEnabled(type != ProjectType.PROJECT);
+					fdescriptionField.setEnabled(type != ProjectType.PROJECT && type != ProjectType.MULTIMODULE_BASIC
+							&& type != ProjectType.MULTIMODULE_STANDARD);
 					if (packagingProviderGroup != null) {
 						packagingProviderGroup.updateEnablement();
 					}
@@ -485,16 +486,22 @@ public class NewRooProjectWizardPageOne extends WizardPage {
 				}
 			}
 			
-			// Roo Addon Suite generation and multimodule generation 
-			// is only available on Spring Roo 2.0+ version
-			if(!version.startsWith("2") && 
-					(getProjectType().equals(ProjectType.ADDON_SUITE) || 
-							getProjectType().equals(ProjectType.MULTIMODULE_BASIC) || 
-							getProjectType().equals(ProjectType.MULTIMODULE_STANDARD))){
-				MessageDialog.openInformation(getShell(), "Spring Roo Alert", "You are trying to use a functionality that is only available on Spring Roo 2.0+ versions."
+			// Roo Addon Suite generation is only available on Spring Roo 2.0+ version
+			if(!version.startsWith("2") && getProjectType().equals(ProjectType.ADDON_SUITE)){
+				MessageDialog.openInformation(getShell(), "Spring Roo Alert", "You are trying to generate an Spring Roo Addon Suite, but this functionality is only available on Spring Roo 2.0+ versions."
 						+ " Please, install an Spring Roo 2.0+ distribution to continue.");
 				fNameGroup.fTemplateField.selectItem(0);
 			}
+			
+			// Multimodule generation is only available on Spring Roo 2.0+ version
+			if (!version.startsWith("2") && (getProjectType().equals(ProjectType.MULTIMODULE_BASIC)
+					|| getProjectType().equals(ProjectType.MULTIMODULE_STANDARD))) {
+				MessageDialog.openInformation(getShell(), "Spring Roo Alert", "You are trying to generate multimodule project, but this functionality is only available on Spring Roo 2.0+ versions."
+						+ " Please, install an Spring Roo 2.0+ distribution to continue.");
+				fNameGroup.fTemplateField.selectItem(0);
+			}
+			
+			
 			
 			
 		}

--- a/plugins/org.springframework.ide.eclipse.roo.ui/src/org/springframework/ide/eclipse/roo/ui/internal/wizard/NewRooProjectWizardPageOne.java
+++ b/plugins/org.springframework.ide.eclipse.roo.ui/src/org/springframework/ide/eclipse/roo/ui/internal/wizard/NewRooProjectWizardPageOne.java
@@ -58,11 +58,15 @@ import org.eclipse.jface.viewers.TreePath;
 import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.ScrolledComposite;
+import org.eclipse.swt.events.ControlAdapter;
+import org.eclipse.swt.events.ControlEvent;
 import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
+import org.eclipse.swt.graphics.Rectangle;
+import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
@@ -1001,41 +1005,52 @@ public class NewRooProjectWizardPageOne extends WizardPage {
 	public void createControl(Composite parent) {
 		initializeDialogUnits(parent);
 
-		final ScrolledComposite scrolledComposite = new ScrolledComposite(parent, SWT.BORDER | SWT.V_SCROLL);
+		final Composite container = new Composite(parent, SWT.NONE);
+		container.setLayout(new FillLayout());
+		
+		final ScrolledComposite scrolledComposite = new ScrolledComposite(container, SWT.BORDER | SWT.V_SCROLL);
+		scrolledComposite.setLayout(new FillLayout());
 		scrolledComposite.setExpandHorizontal(true);
 		scrolledComposite.setExpandVertical(true);
 		scrolledComposite.setAlwaysShowScrollBars(true);
 		
-		Composite composite = new Composite(scrolledComposite, SWT.NULL);
-		composite.setFont(parent.getFont());
-		composite.setLayout(initGridLayout(new GridLayout(1, false), true));
-		composite.setLayoutData(new GridData(GridData.HORIZONTAL_ALIGN_FILL));
+		final Composite subContainer = new Composite(scrolledComposite, SWT.NONE);
+		subContainer.setFont(parent.getFont());
+		subContainer.setLayout(initGridLayout(new GridLayout(1, false), true));
+		subContainer.setLayoutData(new GridData(GridData.HORIZONTAL_ALIGN_FILL));
 		
 		// create UI elements
-		Control nameControl = createNameControl(composite);
+		Control nameControl = createNameControl(subContainer);
 		nameControl.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
 
-		Control rooHomeControl = rooInstallGroup.createControl(composite);
+		Control rooHomeControl = rooInstallGroup.createControl(subContainer);
 		rooHomeControl.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
 
 		if (DependencyManagementUtils.IS_M2ECLIPSE_PRESENT || DependencyManagementUtils.IS_STS_MAVEN_PRESENT) {
-			Control dependencyManagementControl = dependencyManagementGroup.createControl(composite);
+			Control dependencyManagementControl = dependencyManagementGroup.createControl(subContainer);
 			dependencyManagementControl.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
 		}
 		
-		Control providerControl = packagingProviderGroup.createControl(composite);
+		Control providerControl = packagingProviderGroup.createControl(subContainer);
 		providerControl.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
 
-		Control locationControl = createLocationControl(composite);
+		Control locationControl = createLocationControl(subContainer);
 		locationControl.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
 
-		Control workingSetControl = createWorkingSetControl(composite);
+		Control workingSetControl = createWorkingSetControl(subContainer);
 		workingSetControl.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
 		
-		scrolledComposite.setContent(composite);
-		scrolledComposite.setMinSize(composite.computeSize(SWT.DEFAULT, SWT.DEFAULT));
+		scrolledComposite.setContent(subContainer);
+		
+		scrolledComposite.addControlListener(new ControlAdapter() {
+		    public void controlResized(ControlEvent e) {
+		        Rectangle r = scrolledComposite.getClientArea();
+		        scrolledComposite.setMinSize(subContainer
+		                .computeSize(r.width, SWT.DEFAULT));
+		    }
+		});
 
-		setControl(composite);
+		setControl(container);
 	}
 
 	protected void setControl(Control newControl) {

--- a/plugins/org.springframework.ide.eclipse.roo.ui/src/org/springframework/ide/eclipse/roo/ui/internal/wizard/NewRooProjectWizardPageTwo.java
+++ b/plugins/org.springframework.ide.eclipse.roo.ui/src/org/springframework/ide/eclipse/roo/ui/internal/wizard/NewRooProjectWizardPageTwo.java
@@ -1,12 +1,13 @@
 /*******************************************************************************
- *  Copyright (c) 2012 VMware, Inc.
+ *  Copyright (c) 2012 - 2016 GoPivotal, Inc.
  *  All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0
  *  which accompanies this distribution, and is available at
  *  http://www.eclipse.org/legal/epl-v10.html
  *
  *  Contributors:
- *      VMware, Inc. - initial API and implementation
+ *      GoPivotal, Inc. - initial API and implementation
+ *      DISID Corporation, S.L - Spring Roo maintainer
  *******************************************************************************/
 package org.springframework.ide.eclipse.roo.ui.internal.wizard;
 
@@ -28,6 +29,7 @@ import org.springframework.ide.eclipse.roo.ui.internal.StyledTextAppender;
 
 /**
  * @author Christian Dupuis
+ * @author Juan Carlos García
  */
 @SuppressWarnings("restriction")
 public class NewRooProjectWizardPageTwo extends WizardPage {
@@ -49,12 +51,13 @@ public class NewRooProjectWizardPageTwo extends WizardPage {
 
 	public void createControl(Composite parent) {
 		initializeDialogUnits(parent);
-
+		
 		final Composite composite = new Composite(parent, SWT.NULL);
 		composite.setFont(parent.getFont());
 		composite.setLayout(initGridLayout(new GridLayout(1, false), true));
 		composite.setLayoutData(new GridData(GridData.HORIZONTAL_ALIGN_FILL));
 
+		// Create UI Elements
 		text = new StyledText(composite, SWT.MULTI | SWT.BORDER | SWT.V_SCROLL | SWT.WRAP);
 		GridData data = new GridData(GridData.FILL_BOTH);
 		text.setLayoutData(data);
@@ -98,9 +101,7 @@ public class NewRooProjectWizardPageTwo extends WizardPage {
 
 	protected void setControl(Control newControl) {
 		Dialog.applyDialogFont(newControl);
-
 		PlatformUI.getWorkbench().getHelpSystem().setHelp(newControl, IJavaHelpContextIds.NEW_JAVAPROJECT_WIZARD_PAGE);
-
 		super.setControl(newControl);
 	}
 

--- a/plugins/org.springframework.ide.eclipse.ui/src/org/springframework/ide/eclipse/ui/perspective/StsPerspective.java
+++ b/plugins/org.springframework.ide.eclipse.ui/src/org/springframework/ide/eclipse/ui/perspective/StsPerspective.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2012, 2013 GoPivotal, Inc.
+ *  Copyright (c) 2012, 2016 GoPivotal, Inc.
  *  All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0
  *  which accompanies this distribution, and is available at
@@ -7,6 +7,7 @@
  *
  *  Contributors:
  *      VMware, Inc. - initial API and implementation
+ *      DISID Corporation, S.L - Spring Roo maintainer
  *******************************************************************************/
 package org.springframework.ide.eclipse.ui.perspective;
 
@@ -24,6 +25,7 @@ import org.eclipse.ui.texteditor.templates.TemplatesView;
  * Default perspective for STS
  * @author Christian Dupuis
  * @author Steffen Pingel
+ * @author Juan Carlos García
  * @version 2.3.0
  */
 public class StsPerspective implements IPerspectiveFactory {
@@ -126,6 +128,7 @@ public class StsPerspective implements IPerspectiveFactory {
 		layout.addNewWizardShortcut("org.eclipse.ui.editors.wizards.UntitledTextFileWizard");//$NON-NLS-1$
 
 		// new projects
+		layout.addNewWizardShortcut("com.springsource.sts.roo.ui.wizard.newRooProjectWizard");
 		layout.addNewWizardShortcut("org.springsource.ide.eclipse.commons.gettingstarted.wizard.boot.NewSpringBootWizard");
 		layout.addNewWizardShortcut("org.springsource.ide.eclipse.gettingstarted.wizards.import.generic.newalias");
 		layout.addNewWizardShortcut("com.springsource.sts.wizard.template");


### PR DESCRIPTION
Hi!

We've just implemented a new feature that allows developers to generate multimodule projects using Spring Roo Shell.

https://jira.spring.io/browse/ROO-3730

Spring Roo STS Plugin has support to generate standard projects, simple addons, advanced addons and spring roo addon suites... so is necessary that every developer will be able to generate his own multimodule project using STS.

Multimodule projects will be available if some Spring Roo 2.0+ distribution is installed on STS.

Regards,
