### PR TITLE
ROO-3737: Including org.w3c.dom.traversal as extra package on OSGi properties

### DIFF
--- a/plugins/org.springframework.ide.eclipse.roo.core/src/org/springframework/roo/shell/eclipse/Main.java
+++ b/plugins/org.springframework.ide.eclipse.roo.core/src/org/springframework/roo/shell/eclipse/Main.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2012- 2015 VMware, Inc.
+ *  Copyright (c) 2012- 2016 VMware, Inc.
  *  All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0
  *  which accompanies this distribution, and is available at
@@ -214,7 +214,7 @@ public class Main {
 			configProps.put(Constants.FRAMEWORK_STORAGE, cacheDir);
 		}
 
-		configProps.put("org.osgi.framework.system.packages.extra", "org.springsource.ide.eclipse.commons.frameworks.core.internal.plugins");
+		configProps.put("org.osgi.framework.system.packages.extra", "org.springsource.ide.eclipse.commons.frameworks.core.internal.plugins,org.w3c.dom.traversal");
 		configProps.put("roobot.index.dowload", "false");
 		
 		if (shouldCleanCache(cacheDir, rooVersion)) {


### PR DESCRIPTION
We have just included *FreeMarker* template engine on Spring Roo shell to be able to generate views using .ftl templates.

To be able to include FreeMarker bundle, is necessary to include org.w3c.dom.traversal package as extra system package on OSGi Properties.

I've also updated license year ;)

Regards,