### PR TITLE
ROO-3726: Improve import of multimodule projects

### DIFF
--- a/plugins/org.springframework.ide.eclipse.roo.core/META-INF/MANIFEST.MF
+++ b/plugins/org.springframework.ide.eclipse.roo.core/META-INF/MANIFEST.MF
@@ -22,6 +22,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.ajdt.core;bundle-version="2.0.0";resolution:=optional,
  org.springsource.ide.eclipse.commons.configurator,
  org.springframework.ide.eclipse.ui,
+ org.springsource.ide.eclipse.commons.core,
  org.springsource.ide.eclipse.commons.frameworks.core
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Eclipse-LazyStart: true

--- a/plugins/org.springframework.ide.eclipse.roo.ui/src/org/springframework/ide/eclipse/roo/ui/internal/RooShellTab.java
+++ b/plugins/org.springframework.ide.eclipse.roo.ui/src/org/springframework/ide/eclipse/roo/ui/internal/RooShellTab.java
@@ -1,12 +1,13 @@
 /*******************************************************************************
- *  Copyright (c) 2012 VMware, Inc.
+ *  Copyright (c) 2012 - 2016 GoPivotal, Inc.
  *  All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0
  *  which accompanies this distribution, and is available at
  *  http://www.eclipse.org/legal/epl-v10.html
  *
  *  Contributors:
- *      VMware, Inc. - initial API and implementation
+ *      GoPivotal, Inc. - initial API and implementation
+ *      DISID Corporation, S.L - Spring Roo maintainer
  *******************************************************************************/
 package org.springframework.ide.eclipse.roo.ui.internal;
 
@@ -48,7 +49,6 @@ import org.eclipse.swt.custom.StyleRange;
 import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.events.ControlAdapter;
 import org.eclipse.swt.events.ControlEvent;
-import org.eclipse.swt.events.ControlListener;
 import org.eclipse.swt.events.DisposeEvent;
 import org.eclipse.swt.events.DisposeListener;
 import org.eclipse.swt.events.KeyEvent;
@@ -86,6 +86,7 @@ import org.springsource.ide.eclipse.commons.ui.SpringUIUtils;
  * @author Christian Dupuis
  * @author Steffen Pingel
  * @author Kris De Volder
+ * @author Juan Carlos García
  * @since 2.5.0
  */
 public class RooShellTab {
@@ -436,7 +437,7 @@ public class RooShellTab {
 
 				try {
 					ProjectRefresher refresher = new ProjectRefresher(project);
-					bootstrap = new Bootstrap(projectLocation, install.getHome(), install.getVersion(), refresher);
+					bootstrap = new Bootstrap(project, projectLocation, install.getHome(), install.getVersion(), refresher);
 					bootstrap.start(appender, project.getName());
 
 					setEnabled(true);


### PR DESCRIPTION
Hi!

I've just apply some changes on Spring Roo STS Plugin that improve import of multimodule projects that has been generated using Spring Roo Shell.

Now, when developers will create a multimodule project using Spring Roo Shell STS Plugin, a new maven project for every module will be added to STS Workspace:

![All modules has been imported](http://oi68.tinypic.com/241tuo4.jpg)

Every module will be imported with Maven Nature, Spring Nature and AspectJ Nature:

![Module imported](http://oi68.tinypic.com/2w21ugk.jpg)

Parent project will be imported too, because this project is the only one where Spring Roo Shell will works.

![Parent module](http://oi65.tinypic.com/35iogp3.jpg)

I've just include the necessary code to import new generated modules automatically when `module create --moduleName` command will be executed.

Also, I've just included the necessary code to refresh project on package explorer after execute new commands. This will allow developers to show applied changes instantly.