### PR TITLE
ROO-3781: Avoid that Roo console opens automatically when import a project in STS

### DIFF
--- a/plugins/org.springframework.ide.eclipse.roo.ui/src/org/springframework/ide/eclipse/roo/ui/internal/maven/RooProjectConfigurator.java
+++ b/plugins/org.springframework.ide.eclipse.roo.ui/src/org/springframework/ide/eclipse/roo/ui/internal/maven/RooProjectConfigurator.java
@@ -73,10 +73,11 @@ public class RooProjectConfigurator extends AbstractSpringProjectConfigurator {
 					doConfigure(facade.getMavenProject(), facade.getProject(), request, monitor);
 				}
 			}
-			else {
+			// ROO-3781: Commented to prevent that Spring ROO shell was opened automatically
+			/*else {
 				// open the Roo Shell for the project
 				new OpenShellJob(project).schedule();
-			}
+			}*/
 		}
 	}
 


### PR DESCRIPTION
Hi!

I commented the code that opens a Roo Console automatically when you import a project in STS, the reason is that it decreases the elapsed time to import a project and avoids the upgrade automatically of this project.

Regards.