### PR TITLE
ROO-3830 Added integration project when generates a multimodule project

### DIFF
--- a/plugins/org.springframework.ide.eclipse.roo.ui/src/org/springframework/ide/eclipse/roo/ui/internal/wizard/NewRooProjectWizard.java
+++ b/plugins/org.springframework.ide.eclipse.roo.ui/src/org/springframework/ide/eclipse/roo/ui/internal/wizard/NewRooProjectWizard.java
@@ -337,6 +337,15 @@ public class NewRooProjectWizard extends NewElementWizard implements INewWizard 
 						serviceImplModuleProject.setDescription(serviceApiImplDescription, new NullProgressMonitor());
 						modules.add(serviceImplModuleProject);
 						
+						// Import integration module project
+						IProject integrationModuleProject = workspace.getRoot().getProject("integration".concat(":").concat(project.getName()));
+						IProjectDescription integrationModuleDescription = workspace.newProjectDescription("integration".concat(":").concat(project.getName()));
+						integrationModuleDescription.setLocation(new Path(projectLocation + "/integration"));
+						integrationModuleProject.create(integrationModuleDescription, new NullProgressMonitor());
+						integrationModuleProject.open(0, new NullProgressMonitor());
+						integrationModuleProject.setDescription(integrationModuleDescription, new NullProgressMonitor());
+						modules.add(integrationModuleProject);
+						
 						// Import application module project
 						IProject applicationModuleProject = workspace.getRoot().getProject("application".concat(":").concat(project.getName()));
 						IProjectDescription applicationModuleDescription = workspace.newProjectDescription("application".concat(":").concat(project.getName()));


### PR DESCRIPTION
Hi!

When a multimodule project is generated by STS > Create a new Roo Project, all the modules are imported except the integration module. I add that the integration module is imported also.

Regards.
