### PR TITLE
IDE-1393 switch from Require-Bundle...

### DIFF
--- a/plugins/org.springframework.ide.eclipse.quickfix/META-INF/MANIFEST.MF
+++ b/plugins/org.springframework.ide.eclipse.quickfix/META-INF/MANIFEST.MF
@@ -29,7 +29,6 @@ Require-Bundle: org.eclipse.core.resources,
  org.springframework.ide.eclipse.beans.ui.editor,
  org.springsource.ide.eclipse.commons.core,
  org.springframework.ide.eclipse.config.core,
- javax.servlet;bundle-version="2.5.0",
  org.eclipse.ui.workbench.texteditor,
  org.springsource.ide.eclipse.commons.ui
 Bundle-ActivationPolicy: lazy
@@ -51,4 +50,6 @@ Export-Package: org.springframework.ide.eclipse.quickfix,
 Import-Package: org.eclipse.core.runtime,
  org.eclipse.core.runtime.jobs,
  org.eclipse.osgi.util,
+ javax.servlet;version="3.1.0",
+ javax.servlet.http;version="3.1.0",
  org.osgi.framework


### PR DESCRIPTION
IDE-1393 switch from Require-Bundle javax.servlet 2.5.0 to Import-Package javax.servlet(.http) 3.1.0

Signed-off-by: nickboldt <nboldt@redhat.com>