### PR TITLE
ROO-3881: Fixing STS infinite loop after import Spring Roo multimodule project

### DIFF
--- a/plugins/org.springframework.ide.eclipse.roo.ui/plugin.xml
+++ b/plugins/org.springframework.ide.eclipse.roo.ui/plugin.xml
@@ -364,5 +364,28 @@
        </description>
     </colorDefinition>
  </extension>
+ 
+ <extension point="org.eclipse.ui.decorators">
+	<decorator
+	    id="org.springframework.ide.eclipse.roo.ui.internal.listener.RooProjectDecorator"
+	    label="Spring Roo Project Decorator"
+	    lightweight="true"
+	    state="true"
+	    class= "org.springframework.ide.eclipse.roo.ui.internal.listener.RooProjectDecorator">
+	    <description>
+	      Decorates projects to show when a project's classpath contains Spring Roo Elements. 
+	    </description>
+	    <enablement>
+	       <or>
+		       <objectClass
+		             name="org.eclipse.jdt.core.IJavaProject">
+		       </objectClass>
+		       <objectClass
+		             name="org.eclipse.core.resources.IProject">
+		       </objectClass>
+		   </or>
+	    </enablement>
+	  </decorator>
+ </extension>
    	
 </plugin>

--- a/plugins/org.springframework.ide.eclipse.roo.ui/src/org/springframework/ide/eclipse/roo/ui/internal/listener/RooProjectDecorator.java
+++ b/plugins/org.springframework.ide.eclipse.roo.ui/src/org/springframework/ide/eclipse/roo/ui/internal/listener/RooProjectDecorator.java
@@ -21,6 +21,9 @@ import org.springframework.ide.eclipse.roo.core.RooCoreActivator;
 /**
  * Decorates a Spring Roo Project with a '[roo]' text decoration if the
  * project has spring-roo nature
+ * 
+ * Copied from BootProjectDecorator.java class
+ * https://github.com/spring-projects/spring-ide/blob/master/plugins/org.springframework.ide.eclipse.boot/src/org/springframework/ide/eclipse/boot/ui/BootProjectDecorator.java
  *
  * @author Juan Carlos García
  */

--- a/plugins/org.springframework.ide.eclipse.roo.ui/src/org/springframework/ide/eclipse/roo/ui/internal/listener/RooProjectDecorator.java
+++ b/plugins/org.springframework.ide.eclipse.roo.ui/src/org/springframework/ide/eclipse/roo/ui/internal/listener/RooProjectDecorator.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2017 GoPivotal, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     DISID Corporation, S.L - Spring Roo maintainer
+ *******************************************************************************/
+package org.springframework.ide.eclipse.roo.ui.internal.listener;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jface.viewers.IDecoration;
+import org.eclipse.jface.viewers.ILabelProviderListener;
+import org.eclipse.jface.viewers.ILightweightLabelDecorator;
+import org.springframework.ide.eclipse.roo.core.RooCoreActivator;
+
+/**
+ * Decorates a Spring Roo Project with a '[roo]' text decoration if the
+ * project has spring-roo nature
+ *
+ * @author Juan Carlos García
+ */
+public class RooProjectDecorator implements ILightweightLabelDecorator {
+
+	public RooProjectDecorator() {
+	}
+
+	@Override
+	public void addListener(ILabelProviderListener listener) {
+	}
+
+	@Override
+	public void dispose() {
+	}
+
+	@Override
+	public boolean isLabelProperty(Object element, String property) {
+		return false;
+	}
+
+	@Override
+	public void removeListener(ILabelProviderListener listener) {
+	}
+
+	@Override
+	public void decorate(Object element, IDecoration decoration) {
+		IProject project = getProject(element);
+		if (project != null) {
+			try {
+				if(project.getNature(RooCoreActivator.NATURE_ID) != null){
+					decoration.addSuffix(" [roo] ");
+				}
+			}
+			catch (CoreException e) {
+				e.printStackTrace();
+			}
+		}
+	}
+
+	private IProject getProject(Object element) {
+		if (element instanceof IProject) {
+			return (IProject) element;
+		} else if (element instanceof IJavaProject) {
+			return ((IJavaProject) element).getProject();
+		}
+		return null;
+	}
+	
+}

--- a/plugins/org.springframework.ide.eclipse.roo.ui/src/org/springframework/ide/eclipse/roo/ui/internal/maven/RooProjectConfigurator.java
+++ b/plugins/org.springframework.ide.eclipse.roo.ui/src/org/springframework/ide/eclipse/roo/ui/internal/maven/RooProjectConfigurator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2012 - 2013 GoPivotal, Inc.
+ *  Copyright (c) 2012 - 2017 GoPivotal, Inc.
  *  All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0
  *  which accompanies this distribution, and is available at
@@ -7,6 +7,7 @@
  *
  *  Contributors:
  *      GoPivotal, Inc. - initial API and implementation
+ *      DISID Corporation, S.L - Spring Roo maintainer
  *******************************************************************************/
 package org.springframework.ide.eclipse.roo.ui.internal.maven;
 
@@ -30,7 +31,6 @@ import org.springframework.ide.eclipse.core.SpringCore;
 import org.springframework.ide.eclipse.maven.AbstractSpringProjectConfigurator;
 import org.springframework.ide.eclipse.roo.core.RooCoreActivator;
 import org.springframework.ide.eclipse.roo.ui.RooUiActivator;
-import org.springframework.ide.eclipse.roo.ui.internal.actions.OpenShellJob;
 import org.springsource.ide.eclipse.commons.core.SpringCoreUtils;
 
 /**
@@ -50,34 +50,37 @@ public class RooProjectConfigurator extends AbstractSpringProjectConfigurator {
 			IProgressMonitor monitor) throws CoreException {
 		// first apply Roo project nature
 		boolean hasNature = false;
-		for (Artifact art : mavenProject.getArtifacts()) {
-			if (art.getArtifactId().startsWith("org.springframework.roo")
-					&& art.getGroupId().equals("org.springframework.roo")) {
-				SpringCoreUtils.addProjectNature(project, SpringCore.NATURE_ID, monitor);
-				SpringCoreUtils.addProjectNature(project, RooCoreActivator.NATURE_ID, monitor);
-				hasNature = true;
-			}
-		}
-		if (!hasNature) {
-			hasNature = (configureNature(project, mavenProject, SpringCore.NATURE_ID, true, monitor) && configureNature(
-					project, mavenProject, RooCoreActivator.NATURE_ID, true, monitor));
-		}
-
-		if (hasNature) {
-			Artifact parent = mavenProject.getParentArtifact();
-			if (parent != null) {
-				// traverse the parent chain
-				IMavenProjectFacade facade = projectManager.getMavenProject(parent.getGroupId(),
-						parent.getArtifactId(), parent.getVersion());
-				if (facade != null && facade.getMavenProject() != null && facade.getProject() != null) {
-					doConfigure(facade.getMavenProject(), facade.getProject(), request, monitor);
+		// ROO-3881: Only parent modules should be define Spring Roo nature. To identify
+		// if some module is parent or not we're going to check if the parent project is
+		// Spring IO Platform. For multimodule projects, also check if has pom packaging. 
+		MavenProject parent = mavenProject.getParent();
+		boolean isSingleParent = parent != null && parent.getGroupId().equals("io.spring.platform") 
+				&& parent.getArtifactId().equals("platform-bom");
+		boolean isMultimoduleParent = isSingleParent && parent != null && parent.getPackaging().equals("pom");
+		if(isMultimoduleParent){
+			SpringCoreUtils.addProjectNature(project, SpringCore.NATURE_ID, monitor);
+			SpringCoreUtils.addProjectNature(project, RooCoreActivator.NATURE_ID, monitor);
+			hasNature = true;
+		}else {
+			for (Artifact art : mavenProject.getArtifacts()) {
+				if (art.getArtifactId().startsWith("org.springframework.roo")
+						&& art.getGroupId().equals("org.springframework.roo")) {
+					SpringCoreUtils.addProjectNature(project, SpringCore.NATURE_ID, monitor);
+					if(isSingleParent){
+						SpringCoreUtils.addProjectNature(project, RooCoreActivator.NATURE_ID, monitor);
+						hasNature = true;
+					}
 				}
 			}
-			// ROO-3781: Commented to prevent that Spring ROO shell was opened automatically
-			/*else {
-				// open the Roo Shell for the project
-				new OpenShellJob(project).schedule();
-			}*/
+		}
+		
+		if (!hasNature && parent != null) {
+			// traverse the parent chain
+			IMavenProjectFacade facade = projectManager.getMavenProject(parent.getGroupId(),
+					parent.getArtifactId(), parent.getVersion());
+			if (facade != null && facade.getMavenProject() != null && facade.getProject() != null) {
+				doConfigure(facade.getMavenProject(), facade.getProject(), request, monitor);
+			}
 		}
 	}
 

--- a/plugins/org.springframework.ide.eclipse.roo.ui/src/org/springframework/ide/eclipse/roo/ui/internal/wizard/NewRooProjectWizard.java
+++ b/plugins/org.springframework.ide.eclipse.roo.ui/src/org/springframework/ide/eclipse/roo/ui/internal/wizard/NewRooProjectWizard.java
@@ -350,12 +350,6 @@ public class NewRooProjectWizard extends NewElementWizard implements INewWizard 
 					// ROO-3726: If some modules have been imported, configure them.
 					for(IProject module : modules){
 						SpringCoreUtils.addProjectNature(module, SpringCore.NATURE_ID, new NullProgressMonitor());
-						SpringCoreUtils.addProjectNature(module, RooCoreActivator.NATURE_ID, new NullProgressMonitor());
-						
-						SpringCorePreferences.getProjectPreferences(module, RooCoreActivator.PLUGIN_ID).putBoolean(
-								RooCoreActivator.PROJECT_PROPERTY_ID, useDefault);
-						SpringCorePreferences.getProjectPreferences(module, RooCoreActivator.PLUGIN_ID).putString(
-								RooCoreActivator.ROO_INSTALL_PROPERTY, rooInstall);
 						
 						configureProjectUi(module);
 						


### PR DESCRIPTION
Seems like when developers generates a multimodule project using the STS Spring Roo plugin, all modules are imported correctly.

However, if developer creates the multimodule project using Spring Roo from the OS Shell and after tries to import the project to the STS as existing maven project, an infinite loop appears freezing the computer.

This problem doesn't appears with single module projects.

To solve it, only parent modules should be define the Spring Roo nature. To identify if some module is parent or not i'm going to check if the parent project is Spring IO Platform and if it contains Spring Roo dependency. For multimodule projects, also I check if it has pom packaging. 

On the other hand, to identify the module that could be opened with the Spring Roo Shell, I've just created a RooProjectDecorator that will include the "[roo]" flag on the projects that have Spring Roo nature.

![Spring Roo Decorator](http://i.imgur.com/9Hry24P.png)