### PR TITLE
URL Cleanup

### DIFF
--- a/features/org.springframework.ide.eclipse.aeri.feature.source/pom.xml
+++ b/features/org.springframework.ide.eclipse.aeri.feature.source/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/features/org.springframework.ide.eclipse.aeri.feature/pom.xml
+++ b/features/org.springframework.ide.eclipse.aeri.feature/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/features/org.springframework.ide.eclipse.ajdt.feature.source/pom.xml
+++ b/features/org.springframework.ide.eclipse.ajdt.feature.source/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/features/org.springframework.ide.eclipse.ajdt.feature/pom.xml
+++ b/features/org.springframework.ide.eclipse.ajdt.feature/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/features/org.springframework.ide.eclipse.aop.feature.source/pom.xml
+++ b/features/org.springframework.ide.eclipse.aop.feature.source/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/features/org.springframework.ide.eclipse.aop.feature/pom.xml
+++ b/features/org.springframework.ide.eclipse.aop.feature/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/features/org.springframework.ide.eclipse.autowire.feature.source/pom.xml
+++ b/features/org.springframework.ide.eclipse.autowire.feature.source/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/features/org.springframework.ide.eclipse.autowire.feature/pom.xml
+++ b/features/org.springframework.ide.eclipse.autowire.feature/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/features/org.springframework.ide.eclipse.batch.feature.source/pom.xml
+++ b/features/org.springframework.ide.eclipse.batch.feature.source/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/features/org.springframework.ide.eclipse.batch.feature/pom.xml
+++ b/features/org.springframework.ide.eclipse.batch.feature/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/features/org.springframework.ide.eclipse.boot.dash.feature.source/pom.xml
+++ b/features/org.springframework.ide.eclipse.boot.dash.feature.source/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/features/org.springframework.ide.eclipse.boot.dash.feature/pom.xml
+++ b/features/org.springframework.ide.eclipse.boot.dash.feature/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/features/org.springframework.ide.eclipse.boot.feature.source/pom.xml
+++ b/features/org.springframework.ide.eclipse.boot.feature.source/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/features/org.springframework.ide.eclipse.boot.feature/pom.xml
+++ b/features/org.springframework.ide.eclipse.boot.feature/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/features/org.springframework.ide.eclipse.cft.feature.source/pom.xml
+++ b/features/org.springframework.ide.eclipse.cft.feature.source/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/features/org.springframework.ide.eclipse.cft.feature/pom.xml
+++ b/features/org.springframework.ide.eclipse.cft.feature/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/features/org.springframework.ide.eclipse.data.feature.source/pom.xml
+++ b/features/org.springframework.ide.eclipse.data.feature.source/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/features/org.springframework.ide.eclipse.data.feature/pom.xml
+++ b/features/org.springframework.ide.eclipse.data.feature/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
  <modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/features/org.springframework.ide.eclipse.feature.source/pom.xml
+++ b/features/org.springframework.ide.eclipse.feature.source/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/features/org.springframework.ide.eclipse.feature/pom.xml
+++ b/features/org.springframework.ide.eclipse.feature/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/features/org.springframework.ide.eclipse.integration.feature.source/pom.xml
+++ b/features/org.springframework.ide.eclipse.integration.feature.source/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/features/org.springframework.ide.eclipse.integration.feature/pom.xml
+++ b/features/org.springframework.ide.eclipse.integration.feature/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/features/org.springframework.ide.eclipse.maven.feature.source/pom.xml
+++ b/features/org.springframework.ide.eclipse.maven.feature.source/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/features/org.springframework.ide.eclipse.maven.feature/pom.xml
+++ b/features/org.springframework.ide.eclipse.maven.feature/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/features/org.springframework.ide.eclipse.mylyn.feature.source/pom.xml
+++ b/features/org.springframework.ide.eclipse.mylyn.feature.source/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/features/org.springframework.ide.eclipse.mylyn.feature/pom.xml
+++ b/features/org.springframework.ide.eclipse.mylyn.feature/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/features/org.springframework.ide.eclipse.osgi.feature.source/pom.xml
+++ b/features/org.springframework.ide.eclipse.osgi.feature.source/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/features/org.springframework.ide.eclipse.osgi.feature/pom.xml
+++ b/features/org.springframework.ide.eclipse.osgi.feature/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/features/org.springframework.ide.eclipse.roo.feature.source/pom.xml
+++ b/features/org.springframework.ide.eclipse.roo.feature.source/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/features/org.springframework.ide.eclipse.roo.feature/pom.xml
+++ b/features/org.springframework.ide.eclipse.roo.feature/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
  <modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/features/org.springframework.ide.eclipse.security.feature.source/pom.xml
+++ b/features/org.springframework.ide.eclipse.security.feature.source/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/features/org.springframework.ide.eclipse.security.feature/pom.xml
+++ b/features/org.springframework.ide.eclipse.security.feature/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/features/org.springframework.ide.eclipse.webflow.feature.source/pom.xml
+++ b/features/org.springframework.ide.eclipse.webflow.feature.source/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/features/org.springframework.ide.eclipse.webflow.feature/pom.xml
+++ b/features/org.springframework.ide.eclipse.webflow.feature/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.aeri/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.aeri/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.ajdt.ui.visualiser/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.ajdt.ui.visualiser/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.ajdt.ui.xref/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.ajdt.ui.xref/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.aop.core/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.aop.core/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.aop.mylyn/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.aop.mylyn/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.aop.ui.matcher/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.aop.ui.matcher/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.aop.ui/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.aop.ui/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.batch/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.batch/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.beans.core.autowire/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.beans.core.autowire/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.beans.core.groovy.tests/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.beans.core.groovy.tests/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.beans.core.metadata/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.beans.core.metadata/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.beans.core.tests/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.beans.core.tests/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.beans.core.tests/workspace/validation-beanreference-INT-3674/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.beans.core.tests/workspace/validation-beanreference-INT-3674/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.samples</groupId>
   <artifactId>spring-test</artifactId>

--- a/plugins/org.springframework.ide.eclipse.beans.core/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.beans.core/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.beans.mylyn/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.beans.mylyn/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.beans.ui.autowire/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.beans.ui.autowire/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.beans.ui.editor/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.beans.ui.editor/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.beans.ui.graph/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.beans.ui.graph/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.beans.ui.livegraph/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.beans.ui.livegraph/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
  <parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.beans.ui.refactoring/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.beans.ui.refactoring/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.beans.ui.search/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.beans.ui.search/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.beans.ui/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.beans.ui/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.bestpractices.tests/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.bestpractices.tests/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.bestpractices/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.bestpractices/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.boot.dash.test/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.boot.dash.test/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.boot.dash.test/workspace/boot12/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.boot.dash.test/workspace/boot12/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.example</groupId>

--- a/plugins/org.springframework.ide.eclipse.boot.dash.test/workspace/demo-lib/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.boot.dash.test/workspace/demo-lib/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.demo</groupId>
   <artifactId>demo-lib</artifactId>

--- a/plugins/org.springframework.ide.eclipse.boot.dash/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.boot.dash/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.boot.launch.livebean/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.boot.launch.livebean/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.boot.launch.test/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.boot.launch.test/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.boot.launch.test/workspace/dump-info/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.boot.launch.test/workspace/dump-info/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.test</groupId>

--- a/plugins/org.springframework.ide.eclipse.boot.launch.test/workspace/empty-boot-project/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.boot.launch.test/workspace/empty-boot-project/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.test</groupId>

--- a/plugins/org.springframework.ide.eclipse.boot.launch/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.boot.launch/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.boot.properties.editor.test/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.boot.properties.editor.test/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.boot.properties.editor.test/workspace/boot13/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.boot.properties.editor.test/workspace/boot13/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.example</groupId>

--- a/plugins/org.springframework.ide.eclipse.boot.properties.editor.test/workspace/boot13_with_mongo/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.boot.properties.editor.test/workspace/boot13_with_mongo/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.example</groupId>

--- a/plugins/org.springframework.ide.eclipse.boot.properties.editor.test/workspace/demo-deprecation-level/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.boot.properties.editor.test/workspace/demo-deprecation-level/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.example</groupId>

--- a/plugins/org.springframework.ide.eclipse.boot.properties.editor.test/workspace/demo-enum/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.boot.properties.editor.test/workspace/demo-enum/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.test</groupId>

--- a/plugins/org.springframework.ide.eclipse.boot.properties.editor.test/workspace/demo-list-of-pojo/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.boot.properties.editor.test/workspace/demo-list-of-pojo/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.test</groupId>

--- a/plugins/org.springframework.ide.eclipse.boot.properties.editor.test/workspace/demo-live-metadata/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.boot.properties.editor.test/workspace/demo-live-metadata/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.test</groupId>
@@ -21,7 +21,7 @@
 	<repositories>
 	  <repository>
 	    <id>libs-snapshot</id>
-	    <url>http://repo.spring.io/libs-snapshot</url>
+	    <url>https://repo.spring.io/libs-snapshot</url>
 	    <snapshots>
 	      <enabled>true</enabled>
 	    </snapshots>

--- a/plugins/org.springframework.ide.eclipse.boot.properties.editor.test/workspace/demo-sts-4335/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.boot.properties.editor.test/workspace/demo-sts-4335/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.example</groupId>

--- a/plugins/org.springframework.ide.eclipse.boot.properties.editor.test/workspace/demo-with-resource-prop/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.boot.properties.editor.test/workspace/demo-with-resource-prop/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.example</groupId>

--- a/plugins/org.springframework.ide.eclipse.boot.properties.editor.test/workspace/demo/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.boot.properties.editor.test/workspace/demo/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.test</groupId>

--- a/plugins/org.springframework.ide.eclipse.boot.properties.editor.test/workspace/sts-4231/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.boot.properties.editor.test/workspace/sts-4231/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.example</groupId>

--- a/plugins/org.springframework.ide.eclipse.boot.properties.editor.yaml/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.boot.properties.editor.yaml/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.boot.properties.editor/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.boot.properties.editor/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.boot.restart/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.boot.restart/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.boot.templates/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.boot.templates/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.boot.test/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.boot.test/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>
@@ -65,7 +65,7 @@
 				<repository>
 					<id>buildship2</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/buildship/updates/e45/releases/2.x/</url>
+					<url>https://download.eclipse.org/buildship/updates/e45/releases/2.x/</url>
 				</repository>
 			</repositories>
 		</profile>
@@ -75,7 +75,7 @@
 				<repository>
 					<id>buildship2</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/buildship/updates/e46/snapshots/2.x</url>
+					<url>https://download.eclipse.org/buildship/updates/e46/snapshots/2.x</url>
 				</repository>
 			</repositories>
 		</profile>

--- a/plugins/org.springframework.ide.eclipse.boot.test/workspace/simple-boot-project/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.boot.test/workspace/simple-boot-project/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.test</groupId>

--- a/plugins/org.springframework.ide.eclipse.boot.validation/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.boot.validation/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.boot.wizard/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.boot.wizard/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.boot/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.boot/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.buildship/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.buildship/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>
@@ -21,7 +21,7 @@
 				<repository>
 					<id>buildship2</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/buildship/updates/e45/releases/1.0/</url>
+					<url>https://download.eclipse.org/buildship/updates/e45/releases/1.0/</url>
 				</repository>
 			</repositories>
 		</profile>
@@ -31,7 +31,7 @@
 				<repository>
 					<id>buildship2</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/buildship/updates/e46/releases/1.0/</url>
+					<url>https://download.eclipse.org/buildship/updates/e46/releases/1.0/</url>
 				</repository>
 			</repositories>
 		</profile>

--- a/plugins/org.springframework.ide.eclipse.buildship20/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.buildship20/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>
@@ -21,7 +21,7 @@
 				<repository>
 					<id>buildship2</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/buildship/updates/e45/releases/2.x/</url>
+					<url>https://download.eclipse.org/buildship/updates/e45/releases/2.x/</url>
 				</repository>
 			</repositories>
 		</profile>
@@ -31,7 +31,7 @@
 				<repository>
 					<id>buildship2</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/buildship/updates/e46/snapshots/2.x</url>
+					<url>https://download.eclipse.org/buildship/updates/e46/snapshots/2.x</url>
 				</repository>
 			</repositories>
 		</profile>
@@ -41,7 +41,7 @@
 				<repository>
 					<id>buildship2</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/buildship/updates/e47/snapshots/2.x</url>
+					<url>https://download.eclipse.org/buildship/updates/e47/snapshots/2.x</url>
 				</repository>
 			</repositories>
 		</profile>

--- a/plugins/org.springframework.ide.eclipse.cft/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.cft/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.cloudfoundry.manifest.editor/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.cloudfoundry.manifest.editor/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.config.core/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.config.core/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 <modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.config.graph/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.config.graph/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.config.tests/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.config.tests/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.config.ui/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.config.ui/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
  <parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.core/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.core/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.data.core.tests/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.data.core.tests/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.data.core/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.data.core/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.doc/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.doc/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.editor.support/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.editor.support/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.gradle/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.gradle/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.imports/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.imports/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.integration/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.integration/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.maven/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.maven/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.metadata/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.metadata/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.mylyn/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.mylyn/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.osgi.blueprint/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.osgi.blueprint/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.osgi.runtime/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.osgi.runtime/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.osgi.targetdefinition/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.osgi.targetdefinition/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.osgi.targetdefinition/release/download_sources.sh
+++ b/plugins/org.springframework.ide.eclipse.osgi.targetdefinition/release/download_sources.sh
@@ -22,11 +22,11 @@ download_source() {
 }
 
 download_spring_source() {
-	download_source org/springframework $1 $SPRING_VERSION $2 $BUNDLE_SPRING_VERSION spring.source http://repository.springsource.com/maven/bundles/release
+	download_source org/springframework $1 $SPRING_VERSION $2 $BUNDLE_SPRING_VERSION spring.source https://repository.springsource.com/maven/bundles/release
 }
 
 download_osgi_source() {
-	download_source org/springframework/osgi $1 $OSGI_VERSION $2 $BUNDLE_OSGI_VERSION springdm.source http://repository.springsource.com/maven/bundles/release
+	download_source org/springframework/osgi $1 $OSGI_VERSION $2 $BUNDLE_OSGI_VERSION springdm.source https://repository.springsource.com/maven/bundles/release
 }
 
 download_spring_source org.springframework.aop org.springframework.aop 

--- a/plugins/org.springframework.ide.eclipse.osgi.targetdefinition/release/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.osgi.targetdefinition/release/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>${spring.osgi.groupId}</groupId>
 	<artifactId>${spring.osgi.groupId}.target</artifactId>
@@ -150,12 +150,12 @@
 		<repository>
 			<id>com.springsource.repository.bundles.release</id>
 			<name>SpringSource Enterprise Bundle Repository - SpringSource Bundle Releases</name>
-			<url>http://repository.springsource.com/maven/bundles/release</url>
+			<url>https://repository.springsource.com/maven/bundles/release</url>
 		</repository>
 		<repository>
 			<id>com.springsource.repository.bundles.external</id>
 			<name>SpringSource Enterprise Bundle Repository - External Bundle Releases</name>
-			<url>http://repository.springsource.com/maven/bundles/external</url>
+			<url>https://repository.springsource.com/maven/bundles/external</url>
 		</repository>
 	</repositories>
 </project>

--- a/plugins/org.springframework.ide.eclipse.osgi/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.osgi/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.quickfix.tests/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.quickfix.tests/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.quickfix/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.quickfix/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.roo.core/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.roo.core/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.roo.test/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.roo.test/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.springsource.sts</groupId>

--- a/plugins/org.springframework.ide.eclipse.roo.ui/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.roo.ui/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.security/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.security/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.ui/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.ui/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.webflow.core/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.webflow.core/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.webflow.mylyn/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.webflow.mylyn/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.webflow.ui.editor/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.webflow.ui.editor/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.webflow.ui.graph/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.webflow.ui.graph/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.webflow.ui/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.webflow.ui/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse.wizard/pom.xml
+++ b/plugins/org.springframework.ide.eclipse.wizard/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springframework.ide.eclipse/pom.xml
+++ b/plugins/org.springframework.ide.eclipse/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springsource.ide.eclipse.commons.cloudfoundry.client.v2/pom.xml
+++ b/plugins/org.springsource.ide.eclipse.commons.cloudfoundry.client.v2/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>

--- a/plugins/org.springsource.ide.eclipse.commons.gettingstarted.tests/pom.xml
+++ b/plugins/org.springsource.ide.eclipse.commons.gettingstarted.tests/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>
@@ -27,12 +27,12 @@
 				<repository>
 					<id>spring-ide</id>
 					<layout>p2</layout>
-					<url>http://dist.springframework.org/snapshot/IDE/nightly/</url>
+					<url>https://dist.springframework.org/snapshot/IDE/nightly/</url>
 				</repository>
 				<repository>
 					<id>greclipse</id>
 					<layout>p2</layout>
-					<url>http://dist.springsource.org/snapshot/GRECLIPSE/e4.3-j8/</url>
+					<url>https://dist.springsource.org/snapshot/GRECLIPSE/e4.3-j8/</url>
 				</repository>
 			</repositories>
 		</profile>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.ide.eclipse</groupId>
@@ -10,9 +10,9 @@
 
 	<organization>
 		<name>SpringSource, a division of VMware, Inc.</name>
-		<url>http://springsource.com</url>
+		<url>https://springsource.com</url>
 	</organization>
-	<url>http://spring.io/tools</url>
+	<url>https://spring.io/tools</url>
 	<inceptionYear>2004</inceptionYear>
 
 	<prerequisites>
@@ -39,7 +39,7 @@
 	<licenses>
 		<license>
 			<name>Eclipse Public License v1.0</name>
-			<url>http://www.eclipse.org/legal/epl-v10.html</url>
+			<url>https://www.eclipse.org/legal/epl-v10.html</url>
 		</license>
 	</licenses>
 
@@ -83,8 +83,8 @@
 		<maven.test.failure.ignore>false</maven.test.failure.ignore>
 		<encoding>UTF-8</encoding>
 		<test.osvmargs></test.osvmargs>
-		<test.vmargs>${test.osvmargs} -Dreactor.io.epoll=false -Dspring.initializr.json.url=http://start-development.cfapps.io -Dorg.slf4j.simpleLogger.log.cloudfoundry-client=debug</test.vmargs>
-<!--		<test.vmargs>${test.osvmargs} -Dspring.initializr.json.url=http://start.spring.io</test.vmargs> -->
+		<test.vmargs>${test.osvmargs} -Dreactor.io.epoll=false -Dspring.initializr.json.url=https://start-development.cfapps.io -Dorg.slf4j.simpleLogger.log.cloudfoundry-client=debug</test.vmargs>
+<!--		<test.vmargs>${test.osvmargs} -Dspring.initializr.json.url=https://start.spring.io</test.vmargs> -->
 	</properties>
 
 	<modules>
@@ -252,18 +252,18 @@
 			<repositories>
 				<repository>
 					<id>platform-e34</id>
-					<url>http://download.eclipse.org/eclipse/updates/3.4</url>
+					<url>https://download.eclipse.org/eclipse/updates/3.4</url>
 					<layout>p2</layout>
 				</repository>
 				<repository>
 					<id>ganymede</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/releases/ganymede/</url>
+					<url>https://download.eclipse.org/releases/ganymede/</url>
 				</repository>
 				<repository>
 					<id>ajdt-e34</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/tools/ajdt/34/dev/update/</url>
+					<url>https://download.eclipse.org/tools/ajdt/34/dev/update/</url>
 				</repository>
 			</repositories>
 		</profile>
@@ -276,18 +276,18 @@
 			<repositories>
 				<repository>
 					<id>platform-e35</id>
-					<url>http://download.eclipse.org/eclipse/updates/3.5/</url>
+					<url>https://download.eclipse.org/eclipse/updates/3.5/</url>
 					<layout>p2</layout>
 				</repository>
 				<repository>
 					<id>galileo</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/releases/galileo/</url>
+					<url>https://download.eclipse.org/releases/galileo/</url>
 				</repository>
 				<repository>
 					<id>ajdt-e35</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/tools/ajdt/35/dev/update/</url>
+					<url>https://download.eclipse.org/tools/ajdt/35/dev/update/</url>
 				</repository>
 			</repositories>
 		</profile>
@@ -304,22 +304,22 @@
 				<repository>
 					<id>platform-e36</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/eclipse/updates/3.6/</url>
+					<url>https://download.eclipse.org/eclipse/updates/3.6/</url>
 				</repository>
 				<repository>
 					<id>helios</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/releases/helios/</url>
+					<url>https://download.eclipse.org/releases/helios/</url>
 				</repository>
 				<repository>
 					<id>ajdt-e36</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/tools/ajdt/36/milestone/</url>
+					<url>https://download.eclipse.org/tools/ajdt/36/milestone/</url>
 				</repository>
 				<repository>
 					<id>orbit</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/tools/orbit/downloads/drops/R20120526062928/repository/</url>
+					<url>https://download.eclipse.org/tools/orbit/downloads/drops/R20120526062928/repository/</url>
 				</repository>
 			</repositories>
 		</profile>
@@ -336,37 +336,37 @@
 				<repository>
 					<id>platform-e37</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/eclipse/updates/3.7/</url>
+					<url>https://download.eclipse.org/eclipse/updates/3.7/</url>
 				</repository>
 				<repository>
 					<id>indigo</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/releases/indigo/</url>
+					<url>https://download.eclipse.org/releases/indigo/</url>
 				</repository>
 				<repository>
 					<id>ajdt-e37</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/tools/ajdt/37/milestone/</url>
+					<url>https://download.eclipse.org/tools/ajdt/37/milestone/</url>
 				</repository>
 				<repository>
 					<id>orbit</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/tools/orbit/downloads/drops/R20120526062928/repository/</url>
+					<url>https://download.eclipse.org/tools/orbit/downloads/drops/R20120526062928/repository/</url>
 				</repository>
 				<repository>
 					<id>swtbot</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/technology/swtbot/releases/latest/</url>
+					<url>https://download.eclipse.org/technology/swtbot/releases/latest/</url>
 				</repository>
 				<repository>
 		  			<id>groovy</id>
 		  			<layout>p2</layout>
-		  			<url>http://dist.springsource.org/snapshot/GRECLIPSE/e3.7/</url>
+		  			<url>https://dist.springsource.org/snapshot/GRECLIPSE/e3.7/</url>
 				</repository>
 				<repository>
 					<id>eclipse-integration-commons</id>
 					<layout>p2</layout>
-					<url>http://dist.springsource.com/${dist.type}/TOOLS/eclipse-integration-commons/${dist.pathpostfix}/e3.7/</url>
+					<url>https://dist.springsource.com/${dist.type}/TOOLS/eclipse-integration-commons/${dist.pathpostfix}/e3.7/</url>
 				</repository>
 			</repositories>
 		</profile>
@@ -380,37 +380,37 @@
 				<repository>
 					<id>platform-e43</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/eclipse/updates/4.3/</url>
+					<url>https://download.eclipse.org/eclipse/updates/4.3/</url>
 				</repository>
 				<repository>
 					<id>indigo</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/releases/kepler/</url>
+					<url>https://download.eclipse.org/releases/kepler/</url>
 				</repository>
 				<repository>
 					<id>ajdt-e37</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/tools/ajdt/43/milestone/</url>
+					<url>https://download.eclipse.org/tools/ajdt/43/milestone/</url>
 				</repository>
 				<repository>
 					<id>orbit</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/tools/orbit/downloads/drops/R20120526062928/repository/</url>
+					<url>https://download.eclipse.org/tools/orbit/downloads/drops/R20120526062928/repository/</url>
 				</repository>
 				<repository>
 					<id>swtbot</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/technology/swtbot/releases/latest/</url>
+					<url>https://download.eclipse.org/technology/swtbot/releases/latest/</url>
 				</repository>
 				<repository>
 		  			<id>groovy</id>
 		  			<layout>p2</layout>
-		  			<url>http://dist.springsource.org/snapshot/GRECLIPSE/e4.3/</url>
+		  			<url>https://dist.springsource.org/snapshot/GRECLIPSE/e4.3/</url>
 				</repository>
 				<repository>
 					<id>eclipse-integration-commons</id>
 					<layout>p2</layout>
-					<url>http://dist.springsource.com/${dist.type}/TOOLS/eclipse-integration-commons/${dist.pathpostfix}/e3.7/</url>
+					<url>https://dist.springsource.com/${dist.type}/TOOLS/eclipse-integration-commons/${dist.pathpostfix}/e3.7/</url>
 				</repository>
 			</repositories>
 		</profile>
@@ -424,42 +424,42 @@
 				<repository>
 					<id>platform-e44</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/eclipse/updates/4.4/</url>
+					<url>https://download.eclipse.org/eclipse/updates/4.4/</url>
 				</repository>
 				<repository>
 					<id>luna</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/releases/luna/</url>
+					<url>https://download.eclipse.org/releases/luna/</url>
 				</repository>
 				<repository>
 					<id>ajdt-e44</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/tools/ajdt/44/dev/update/</url>
+					<url>https://download.eclipse.org/tools/ajdt/44/dev/update/</url>
 				</repository>
 				<repository>
 					<id>m2e-16</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/technology/m2e/releases/1.6/</url>
+					<url>https://download.eclipse.org/technology/m2e/releases/1.6/</url>
 				</repository>
 				<repository>
 					<id>orbit-luna-SR1</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/tools/orbit/downloads/drops/R20140525021250/repository/</url>
+					<url>https://download.eclipse.org/tools/orbit/downloads/drops/R20140525021250/repository/</url>
 				</repository>
 				<repository>
 					<id>swtbot</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/technology/swtbot/releases/latest/</url>
+					<url>https://download.eclipse.org/technology/swtbot/releases/latest/</url>
 				</repository>
 				<repository>
 		  			<id>groovy</id>
 		  			<layout>p2</layout>
-		  			<url>http://dist.springsource.org/snapshot/GRECLIPSE/e4.4/</url>
+		  			<url>https://dist.springsource.org/snapshot/GRECLIPSE/e4.4/</url>
 				</repository>
 				<repository>
 					<id>eclipse-integration-commons</id>
 					<layout>p2</layout>
-					<url>http://dist.springsource.com/${dist.type}/TOOLS/eclipse-integration-commons/${dist.pathpostfix}/e4.4/</url>
+					<url>https://dist.springsource.com/${dist.type}/TOOLS/eclipse-integration-commons/${dist.pathpostfix}/e4.4/</url>
 				</repository>
 			</repositories>
 		</profile>
@@ -473,42 +473,42 @@
 				<repository>
 					<id>platform-e45</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/eclipse/updates/4.5/</url>
+					<url>https://download.eclipse.org/eclipse/updates/4.5/</url>
 				</repository>
 				<repository>
 					<id>mars</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/releases/mars/</url>
+					<url>https://download.eclipse.org/releases/mars/</url>
 				</repository>
 				<repository>
 					<id>ajdt</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/tools/ajdt/45/dev/update</url>
+					<url>https://download.eclipse.org/tools/ajdt/45/dev/update</url>
 				</repository>
 				<repository>
 					<id>orbit-mars</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/tools/orbit/downloads/drops/R20150519210750/repository/</url>
+					<url>https://download.eclipse.org/tools/orbit/downloads/drops/R20150519210750/repository/</url>
 				</repository>
 				<repository>
 					<id>swtbot</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/technology/swtbot/releases/latest/</url>
+					<url>https://download.eclipse.org/technology/swtbot/releases/latest/</url>
 				</repository>
 				<repository>
 		  			<id>groovy</id>
 		  			<layout>p2</layout>
-		  			<url>http://dist.springsource.org/snapshot/GRECLIPSE/e4.5/</url>
+		  			<url>https://dist.springsource.org/snapshot/GRECLIPSE/e4.5/</url>
 				</repository>
 				<repository>
 					<id>cft</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/cft/1.0.1.RC1/</url>
+					<url>https://download.eclipse.org/cft/1.0.1.RC1/</url>
 				</repository>
 				<repository>
 					<id>eclipse-integration-commons</id>
 					<layout>p2</layout>
-					<url>http://dist.springsource.com/${dist.type}/TOOLS/eclipse-integration-commons/${dist.pathpostfix}</url>
+					<url>https://dist.springsource.com/${dist.type}/TOOLS/eclipse-integration-commons/${dist.pathpostfix}</url>
 				</repository>
 			</repositories>
 		</profile>
@@ -522,57 +522,57 @@
 				<repository>
 					<id>platform-e46</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/eclipse/updates/4.6/</url>
+					<url>https://download.eclipse.org/eclipse/updates/4.6/</url>
 				</repository>
 				<repository>
 					<id>mars</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/releases/neon/</url>
+					<url>https://download.eclipse.org/releases/neon/</url>
 				</repository>
 				<repository>
 					<id>ajdt</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/tools/ajdt/46/dev/update</url>
+					<url>https://download.eclipse.org/tools/ajdt/46/dev/update</url>
 				</repository>
 				<repository>
 					<id>orbit-neon</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/tools/orbit/downloads/drops/R20170307180635/repository/</url>
+					<url>https://download.eclipse.org/tools/orbit/downloads/drops/R20170307180635/repository/</url>
 				</repository>
 				<repository>
 					<id>mylyn</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/mylyn/releases/latest</url>
+					<url>https://download.eclipse.org/mylyn/releases/latest</url>
 				</repository>
 				<repository>
 					<id>mylyn-docs</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/mylyn/docs/releases/3.0</url>
+					<url>https://download.eclipse.org/mylyn/docs/releases/3.0</url>
 				</repository>
 				<repository>
 					<id>swtbot</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/technology/swtbot/releases/latest/</url>
+					<url>https://download.eclipse.org/technology/swtbot/releases/latest/</url>
 				</repository>
 				<repository>
 		  			<id>groovy</id>
 		  			<layout>p2</layout>
-		  			<url>http://dist.springsource.org/snapshot/GRECLIPSE/e4.6/</url>
+		  			<url>https://dist.springsource.org/snapshot/GRECLIPSE/e4.6/</url>
 				</repository>
 				<repository>
 					<id>cft</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/cft/1.1.0.RC2/</url>
+					<url>https://download.eclipse.org/cft/1.1.0.RC2/</url>
 				</repository>
 				<repository>
 					<id>lsp4e</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/lsp4e/snapshots/</url>
+					<url>https://download.eclipse.org/lsp4e/snapshots/</url>
 				</repository>
 				<repository>
 					<id>eclipse-integration-commons</id>
 					<layout>p2</layout>
-					<url>http://dist.springsource.com/${dist.type}/TOOLS/eclipse-integration-commons/${dist.pathpostfix}</url>
+					<url>https://dist.springsource.com/${dist.type}/TOOLS/eclipse-integration-commons/${dist.pathpostfix}</url>
 				</repository>
 			</repositories>
 		</profile>
@@ -586,52 +586,52 @@
 				<repository>
 					<id>platform-e47</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/eclipse/updates/4.7/</url>
+					<url>https://download.eclipse.org/eclipse/updates/4.7/</url>
 				</repository>
 				<repository>
 					<id>oxygen</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/releases/oxygen/</url>
+					<url>https://download.eclipse.org/releases/oxygen/</url>
 				</repository>
 				<repository>
 					<id>ajdt</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/tools/ajdt/47/dev/update</url>
+					<url>https://download.eclipse.org/tools/ajdt/47/dev/update</url>
 				</repository>
 				<repository>
 					<id>orbit-oxygen</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/tools/orbit/downloads/drops/R20170516192513/repository/</url>
+					<url>https://download.eclipse.org/tools/orbit/downloads/drops/R20170516192513/repository/</url>
 				</repository>
 				<repository>
 					<id>swtbot</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/technology/swtbot/releases/latest/</url>
+					<url>https://download.eclipse.org/technology/swtbot/releases/latest/</url>
 				</repository>
 				<repository>
 		  			<id>groovy</id>
 		  			<layout>p2</layout>
-		  			<url>http://dist.springsource.org/snapshot/GRECLIPSE/e4.7/</url>
+		  			<url>https://dist.springsource.org/snapshot/GRECLIPSE/e4.7/</url>
 				</repository>
 				<repository>
 					<id>cft</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/cft/1.1.0.RC2/</url>
+					<url>https://download.eclipse.org/cft/1.1.0.RC2/</url>
 				</repository>
 				<repository>
 		  			<id>buildship-for-testing</id>
 		  			<layout>p2</layout>
-		  			<url>http://download.eclipse.org/buildship/updates/e46/releases/1.0/</url>
+		  			<url>https://download.eclipse.org/buildship/updates/e46/releases/1.0/</url>
 				</repository>
 				<repository>
 					<id>lsp4e</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/lsp4e/snapshots/</url>
+					<url>https://download.eclipse.org/lsp4e/snapshots/</url>
 				</repository>
 				<repository>
 					<id>eclipse-integration-commons</id>
 					<layout>p2</layout>
-					<url>http://dist.springsource.com/${dist.type}/TOOLS/eclipse-integration-commons/${dist.pathpostfix}</url>
+					<url>https://dist.springsource.com/${dist.type}/TOOLS/eclipse-integration-commons/${dist.pathpostfix}</url>
 				</repository>
 			</repositories>
 		</profile>
@@ -674,23 +674,23 @@
 		<repository>
 			<id>eclipse-integration-gradle</id>
 			<layout>p2</layout>
-			<url>http://dist.springsource.com/${dist.type}/TOOLS/gradle/${dist.pathpostfix}</url>
+			<url>https://dist.springsource.com/${dist.type}/TOOLS/gradle/${dist.pathpostfix}</url>
 		</repository>
 		<repository>
 			<!-- necessary for maven and ant AWS dependency -->
 			<id>springsource-maven-release</id>
 			<name>SpringSource Maven Release Repository</name>
-			<url>http://repository.springsource.com/maven/bundles/release</url>
+			<url>https://repository.springsource.com/maven/bundles/release</url>
 		</repository>
 		<repository>
 			<id>mylyn-37</id>
 			<layout>p2</layout>
-			<url>http://download.eclipse.org/mylyn/releases/3.7</url>
+			<url>https://download.eclipse.org/mylyn/releases/3.7</url>
 		</repository>
 		<repository>
 			<id>yedit</id>
 			<layout>p2</layout>
-			<url>http://dist.springsource.com/release/TOOLS/third-party/yedit</url>
+			<url>https://dist.springsource.com/release/TOOLS/third-party/yedit</url>
 		</repository>
 		<repository>
 			<id>kotlin-eclipse</id>
@@ -700,7 +700,7 @@
 <!-- 		<repository> -->
 <!-- 			<id>yedit</id> -->
 <!-- 			<layout>p2</layout> -->
-<!-- 			<url>http://dadacoalition.org/yedit</url> -->
+<!-- 			<url>http://dadacoalition.org/yedit/</url> -->
 <!-- 		</repository>  -->
 	</repositories>
 
@@ -708,13 +708,13 @@
 		<pluginRepository>
 			<id>spring-maven-release</id>
 			<name>Spring Maven Release Repository</name>
-			<url>http://maven.springframework.org/release</url>
+			<url>https://maven.springframework.org/release</url>
 		</pluginRepository>
 		<!-- necessary for maven and ant AWS dependency -->
 		<pluginRepository>
 			<id>springsource-maven-release</id>
 			<name>SpringSource Maven Release Repository</name>
-			<url>http://repository.springsource.com/maven/bundles/release</url>
+			<url>https://repository.springsource.com/maven/bundles/release</url>
 		</pluginRepository>
 		<pluginRepository>
 			<id>sonatype.snapshots</id>

--- a/projects/org.springframework.roo.addon.roobot.client/pom.xml
+++ b/projects/org.springframework.roo.addon.roobot.client/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.springframework.roo</groupId>

--- a/projects/org.springframework.roo.addon.roobot.eclipse.api/pom.xml
+++ b/projects/org.springframework.roo.addon.roobot.eclipse.api/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <!--
   <parent>

--- a/projects/org.springframework.roo.shell.eclipse/pom.xml
+++ b/projects/org.springframework.roo.shell.eclipse/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.springframework.roo</groupId>

--- a/releng/org.springframework.ide.eclipse.site/pom.xml
+++ b/releng/org.springframework.ide.eclipse.site/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ide.eclipse</groupId>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://timestamp.digicert.com (200) with 1 occurrences could not be migrated:  
   ([https](https://timestamp.digicert.com) result AnnotatedConnectException).
* http://dadacoalition.org/yedit (301) with 1 occurrences could not be migrated:  
   ([https](https://dadacoalition.org/yedit) result SSLHandshakeException).
* http://sha256timestamp.ws.symantec.com/sha256/timestamp (400) with 1 occurrences could not be migrated:  
   ([https](https://sha256timestamp.ws.symantec.com/sha256/timestamp) result ConnectTimeoutException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://dist.springsource.com/ (403) with 7 occurrences migrated to:  
  https://dist.springsource.com/ ([https](https://dist.springsource.com/) result 403).
* http://dist.springsource.com/release/TOOLS/third-party/yedit (403) with 1 occurrences migrated to:  
  https://dist.springsource.com/release/TOOLS/third-party/yedit ([https](https://dist.springsource.com/release/TOOLS/third-party/yedit) result 403).
* http://download.eclipse.org/tools/ajdt/34/dev/update/ (404) with 1 occurrences migrated to:  
  https://download.eclipse.org/tools/ajdt/34/dev/update/ ([https](https://download.eclipse.org/tools/ajdt/34/dev/update/) result 404).
* http://repository.springsource.com/maven/bundles/external (404) with 1 occurrences migrated to:  
  https://repository.springsource.com/maven/bundles/external ([https](https://repository.springsource.com/maven/bundles/external) result 404).
* http://repository.springsource.com/maven/bundles/release (404) with 5 occurrences migrated to:  
  https://repository.springsource.com/maven/bundles/release ([https](https://repository.springsource.com/maven/bundles/release) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://dist.springframework.org/snapshot/IDE/nightly/ with 1 occurrences migrated to:  
  https://dist.springframework.org/snapshot/IDE/nightly/ ([https](https://dist.springframework.org/snapshot/IDE/nightly/) result 200).
* http://dist.springsource.org/snapshot/GRECLIPSE/e3.7/ with 1 occurrences migrated to:  
  https://dist.springsource.org/snapshot/GRECLIPSE/e3.7/ ([https](https://dist.springsource.org/snapshot/GRECLIPSE/e3.7/) result 200).
* http://dist.springsource.org/snapshot/GRECLIPSE/e4.3-j8/ with 1 occurrences migrated to:  
  https://dist.springsource.org/snapshot/GRECLIPSE/e4.3-j8/ ([https](https://dist.springsource.org/snapshot/GRECLIPSE/e4.3-j8/) result 200).
* http://dist.springsource.org/snapshot/GRECLIPSE/e4.3/ with 1 occurrences migrated to:  
  https://dist.springsource.org/snapshot/GRECLIPSE/e4.3/ ([https](https://dist.springsource.org/snapshot/GRECLIPSE/e4.3/) result 200).
* http://dist.springsource.org/snapshot/GRECLIPSE/e4.4/ with 1 occurrences migrated to:  
  https://dist.springsource.org/snapshot/GRECLIPSE/e4.4/ ([https](https://dist.springsource.org/snapshot/GRECLIPSE/e4.4/) result 200).
* http://dist.springsource.org/snapshot/GRECLIPSE/e4.5/ with 1 occurrences migrated to:  
  https://dist.springsource.org/snapshot/GRECLIPSE/e4.5/ ([https](https://dist.springsource.org/snapshot/GRECLIPSE/e4.5/) result 200).
* http://dist.springsource.org/snapshot/GRECLIPSE/e4.6/ with 1 occurrences migrated to:  
  https://dist.springsource.org/snapshot/GRECLIPSE/e4.6/ ([https](https://dist.springsource.org/snapshot/GRECLIPSE/e4.6/) result 200).
* http://dist.springsource.org/snapshot/GRECLIPSE/e4.7/ with 1 occurrences migrated to:  
  https://dist.springsource.org/snapshot/GRECLIPSE/e4.7/ ([https](https://dist.springsource.org/snapshot/GRECLIPSE/e4.7/) result 200).
* http://download.eclipse.org/buildship/updates/e45/releases/1.0/ with 1 occurrences migrated to:  
  https://download.eclipse.org/buildship/updates/e45/releases/1.0/ ([https](https://download.eclipse.org/buildship/updates/e45/releases/1.0/) result 200).
* http://download.eclipse.org/buildship/updates/e45/releases/2.x/ with 2 occurrences migrated to:  
  https://download.eclipse.org/buildship/updates/e45/releases/2.x/ ([https](https://download.eclipse.org/buildship/updates/e45/releases/2.x/) result 200).
* http://download.eclipse.org/buildship/updates/e46/releases/1.0/ with 2 occurrences migrated to:  
  https://download.eclipse.org/buildship/updates/e46/releases/1.0/ ([https](https://download.eclipse.org/buildship/updates/e46/releases/1.0/) result 200).
* http://download.eclipse.org/cft/1.0.1.RC1/ with 1 occurrences migrated to:  
  https://download.eclipse.org/cft/1.0.1.RC1/ ([https](https://download.eclipse.org/cft/1.0.1.RC1/) result 200).
* http://download.eclipse.org/cft/1.1.0.RC2/ with 2 occurrences migrated to:  
  https://download.eclipse.org/cft/1.1.0.RC2/ ([https](https://download.eclipse.org/cft/1.1.0.RC2/) result 200).
* http://download.eclipse.org/eclipse/updates/3.5/ with 1 occurrences migrated to:  
  https://download.eclipse.org/eclipse/updates/3.5/ ([https](https://download.eclipse.org/eclipse/updates/3.5/) result 200).
* http://download.eclipse.org/eclipse/updates/3.6/ with 1 occurrences migrated to:  
  https://download.eclipse.org/eclipse/updates/3.6/ ([https](https://download.eclipse.org/eclipse/updates/3.6/) result 200).
* http://download.eclipse.org/eclipse/updates/3.7/ with 1 occurrences migrated to:  
  https://download.eclipse.org/eclipse/updates/3.7/ ([https](https://download.eclipse.org/eclipse/updates/3.7/) result 200).
* http://download.eclipse.org/eclipse/updates/4.3/ with 1 occurrences migrated to:  
  https://download.eclipse.org/eclipse/updates/4.3/ ([https](https://download.eclipse.org/eclipse/updates/4.3/) result 200).
* http://download.eclipse.org/eclipse/updates/4.4/ with 1 occurrences migrated to:  
  https://download.eclipse.org/eclipse/updates/4.4/ ([https](https://download.eclipse.org/eclipse/updates/4.4/) result 200).
* http://download.eclipse.org/eclipse/updates/4.5/ with 1 occurrences migrated to:  
  https://download.eclipse.org/eclipse/updates/4.5/ ([https](https://download.eclipse.org/eclipse/updates/4.5/) result 200).
* http://download.eclipse.org/eclipse/updates/4.6/ with 1 occurrences migrated to:  
  https://download.eclipse.org/eclipse/updates/4.6/ ([https](https://download.eclipse.org/eclipse/updates/4.6/) result 200).
* http://download.eclipse.org/eclipse/updates/4.7/ with 1 occurrences migrated to:  
  https://download.eclipse.org/eclipse/updates/4.7/ ([https](https://download.eclipse.org/eclipse/updates/4.7/) result 200).
* http://download.eclipse.org/lsp4e/snapshots/ with 2 occurrences migrated to:  
  https://download.eclipse.org/lsp4e/snapshots/ ([https](https://download.eclipse.org/lsp4e/snapshots/) result 200).
* http://download.eclipse.org/releases/galileo/ with 1 occurrences migrated to:  
  https://download.eclipse.org/releases/galileo/ ([https](https://download.eclipse.org/releases/galileo/) result 200).
* http://download.eclipse.org/releases/ganymede/ with 1 occurrences migrated to:  
  https://download.eclipse.org/releases/ganymede/ ([https](https://download.eclipse.org/releases/ganymede/) result 200).
* http://download.eclipse.org/releases/helios/ with 1 occurrences migrated to:  
  https://download.eclipse.org/releases/helios/ ([https](https://download.eclipse.org/releases/helios/) result 200).
* http://download.eclipse.org/releases/indigo/ with 1 occurrences migrated to:  
  https://download.eclipse.org/releases/indigo/ ([https](https://download.eclipse.org/releases/indigo/) result 200).
* http://download.eclipse.org/releases/kepler/ with 1 occurrences migrated to:  
  https://download.eclipse.org/releases/kepler/ ([https](https://download.eclipse.org/releases/kepler/) result 200).
* http://download.eclipse.org/releases/luna/ with 1 occurrences migrated to:  
  https://download.eclipse.org/releases/luna/ ([https](https://download.eclipse.org/releases/luna/) result 200).
* http://download.eclipse.org/releases/mars/ with 1 occurrences migrated to:  
  https://download.eclipse.org/releases/mars/ ([https](https://download.eclipse.org/releases/mars/) result 200).
* http://download.eclipse.org/releases/neon/ with 1 occurrences migrated to:  
  https://download.eclipse.org/releases/neon/ ([https](https://download.eclipse.org/releases/neon/) result 200).
* http://download.eclipse.org/releases/oxygen/ with 1 occurrences migrated to:  
  https://download.eclipse.org/releases/oxygen/ ([https](https://download.eclipse.org/releases/oxygen/) result 200).
* http://download.eclipse.org/technology/m2e/releases/1.6/ with 1 occurrences migrated to:  
  https://download.eclipse.org/technology/m2e/releases/1.6/ ([https](https://download.eclipse.org/technology/m2e/releases/1.6/) result 200).
* http://download.eclipse.org/technology/swtbot/releases/latest/ with 6 occurrences migrated to:  
  https://download.eclipse.org/technology/swtbot/releases/latest/ ([https](https://download.eclipse.org/technology/swtbot/releases/latest/) result 200).
* http://download.eclipse.org/tools/ajdt/35/dev/update/ with 1 occurrences migrated to:  
  https://download.eclipse.org/tools/ajdt/35/dev/update/ ([https](https://download.eclipse.org/tools/ajdt/35/dev/update/) result 200).
* http://download.eclipse.org/tools/ajdt/36/milestone/ with 1 occurrences migrated to:  
  https://download.eclipse.org/tools/ajdt/36/milestone/ ([https](https://download.eclipse.org/tools/ajdt/36/milestone/) result 200).
* http://download.eclipse.org/tools/ajdt/37/milestone/ with 1 occurrences migrated to:  
  https://download.eclipse.org/tools/ajdt/37/milestone/ ([https](https://download.eclipse.org/tools/ajdt/37/milestone/) result 200).
* http://download.eclipse.org/tools/ajdt/43/milestone/ with 1 occurrences migrated to:  
  https://download.eclipse.org/tools/ajdt/43/milestone/ ([https](https://download.eclipse.org/tools/ajdt/43/milestone/) result 200).
* http://download.eclipse.org/tools/ajdt/44/dev/update/ with 1 occurrences migrated to:  
  https://download.eclipse.org/tools/ajdt/44/dev/update/ ([https](https://download.eclipse.org/tools/ajdt/44/dev/update/) result 200).
* http://download.eclipse.org/tools/orbit/downloads/drops/R20120526062928/repository/ with 3 occurrences migrated to:  
  https://download.eclipse.org/tools/orbit/downloads/drops/R20120526062928/repository/ ([https](https://download.eclipse.org/tools/orbit/downloads/drops/R20120526062928/repository/) result 200).
* http://download.eclipse.org/tools/orbit/downloads/drops/R20140525021250/repository/ with 1 occurrences migrated to:  
  https://download.eclipse.org/tools/orbit/downloads/drops/R20140525021250/repository/ ([https](https://download.eclipse.org/tools/orbit/downloads/drops/R20140525021250/repository/) result 200).
* http://download.eclipse.org/tools/orbit/downloads/drops/R20150519210750/repository/ with 1 occurrences migrated to:  
  https://download.eclipse.org/tools/orbit/downloads/drops/R20150519210750/repository/ ([https](https://download.eclipse.org/tools/orbit/downloads/drops/R20150519210750/repository/) result 200).
* http://download.eclipse.org/tools/orbit/downloads/drops/R20170307180635/repository/ with 1 occurrences migrated to:  
  https://download.eclipse.org/tools/orbit/downloads/drops/R20170307180635/repository/ ([https](https://download.eclipse.org/tools/orbit/downloads/drops/R20170307180635/repository/) result 200).
* http://download.eclipse.org/tools/orbit/downloads/drops/R20170516192513/repository/ with 1 occurrences migrated to:  
  https://download.eclipse.org/tools/orbit/downloads/drops/R20170516192513/repository/ ([https](https://download.eclipse.org/tools/orbit/downloads/drops/R20170516192513/repository/) result 200).
* http://maven.apache.org/xsd/maven-4.0.0.xsd with 17 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* http://spring.io/tools with 1 occurrences migrated to:  
  https://spring.io/tools ([https](https://spring.io/tools) result 200).
* http://start-development.cfapps.io with 1 occurrences migrated to:  
  https://start-development.cfapps.io ([https](https://start-development.cfapps.io) result 200).
* http://start.spring.io with 1 occurrences migrated to:  
  https://start.spring.io ([https](https://start.spring.io) result 200).
* http://www.eclipse.org/legal/epl-v10.html with 1 occurrences migrated to:  
  https://www.eclipse.org/legal/epl-v10.html ([https](https://www.eclipse.org/legal/epl-v10.html) result 200).
* http://download.eclipse.org/buildship/updates/e46/snapshots/2.x with 2 occurrences migrated to:  
  https://download.eclipse.org/buildship/updates/e46/snapshots/2.x ([https](https://download.eclipse.org/buildship/updates/e46/snapshots/2.x) result 301).
* http://download.eclipse.org/buildship/updates/e47/snapshots/2.x with 1 occurrences migrated to:  
  https://download.eclipse.org/buildship/updates/e47/snapshots/2.x ([https](https://download.eclipse.org/buildship/updates/e47/snapshots/2.x) result 301).
* http://download.eclipse.org/eclipse/updates/3.4 with 1 occurrences migrated to:  
  https://download.eclipse.org/eclipse/updates/3.4 ([https](https://download.eclipse.org/eclipse/updates/3.4) result 301).
* http://download.eclipse.org/mylyn/docs/releases/3.0 with 1 occurrences migrated to:  
  https://download.eclipse.org/mylyn/docs/releases/3.0 ([https](https://download.eclipse.org/mylyn/docs/releases/3.0) result 301).
* http://download.eclipse.org/mylyn/releases/3.7 with 1 occurrences migrated to:  
  https://download.eclipse.org/mylyn/releases/3.7 ([https](https://download.eclipse.org/mylyn/releases/3.7) result 301).
* http://download.eclipse.org/mylyn/releases/latest with 1 occurrences migrated to:  
  https://download.eclipse.org/mylyn/releases/latest ([https](https://download.eclipse.org/mylyn/releases/latest) result 301).
* http://download.eclipse.org/tools/ajdt/45/dev/update with 1 occurrences migrated to:  
  https://download.eclipse.org/tools/ajdt/45/dev/update ([https](https://download.eclipse.org/tools/ajdt/45/dev/update) result 301).
* http://download.eclipse.org/tools/ajdt/46/dev/update with 1 occurrences migrated to:  
  https://download.eclipse.org/tools/ajdt/46/dev/update ([https](https://download.eclipse.org/tools/ajdt/46/dev/update) result 301).
* http://download.eclipse.org/tools/ajdt/47/dev/update with 1 occurrences migrated to:  
  https://download.eclipse.org/tools/ajdt/47/dev/update ([https](https://download.eclipse.org/tools/ajdt/47/dev/update) result 301).
* http://maven.apache.org/maven-v4_0_0.xsd with 115 occurrences migrated to:  
  https://maven.apache.org/maven-v4_0_0.xsd ([https](https://maven.apache.org/maven-v4_0_0.xsd) result 301).
* http://springsource.com with 1 occurrences migrated to:  
  https://springsource.com ([https](https://springsource.com) result 301).
* http://maven.springframework.org/release with 1 occurrences migrated to:  
  https://maven.springframework.org/release ([https](https://maven.springframework.org/release) result 302).
* http://repo.spring.io/libs-snapshot with 1 occurrences migrated to:  
  https://repo.spring.io/libs-snapshot ([https](https://repo.spring.io/libs-snapshot) result 302).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0 with 264 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 132 occurrences