### PR TITLE
URL Cleanup

### DIFF
--- a/features/org.springframework.ide.eclipse.aeri.feature.source/feature.properties
+++ b/features/org.springframework.ide.eclipse.aeri.feature.source/feature.properties
@@ -65,8 +65,8 @@ Note: if a Feature made available by the Spring IDE project is installed using t
 THE ABOUTS, FEATURE LICENSES, AND FEATURE UPDATE LICENSES MAY REFER TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS. SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):\n\
 \n\
    - Common Public License Version 1.0 (available at http://www.eclipse.org/legal/cpl-v10.html)\n\
-   - Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)\n\
-   - Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)\n\
+   - Apache Software License 1.1 (available at https://www.apache.org/licenses/LICENSE)\n\
+   - Apache Software License 2.0 (available at https://www.apache.org/licenses/LICENSE-2.0)\n\
    - IBM Public License 1.0 (available at http://oss.software.ibm.com/developerworks/opensource/license10.html)\n\
    - Metro Link Public License 1.00 (available at http://www.opengroup.org/openmotif/supporters/metrolink/license.html)\n\
    - Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)\n\

--- a/features/org.springframework.ide.eclipse.aeri.feature/feature.properties
+++ b/features/org.springframework.ide.eclipse.aeri.feature/feature.properties
@@ -65,8 +65,8 @@ Note: if a Feature made available by the Spring IDE project is installed using t
 THE ABOUTS, FEATURE LICENSES, AND FEATURE UPDATE LICENSES MAY REFER TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS. SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):\n\
 \n\
    - Common Public License Version 1.0 (available at http://www.eclipse.org/legal/cpl-v10.html)\n\
-   - Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)\n\
-   - Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)\n\
+   - Apache Software License 1.1 (available at https://www.apache.org/licenses/LICENSE)\n\
+   - Apache Software License 2.0 (available at https://www.apache.org/licenses/LICENSE-2.0)\n\
    - IBM Public License 1.0 (available at http://oss.software.ibm.com/developerworks/opensource/license10.html)\n\
    - Metro Link Public License 1.00 (available at http://www.opengroup.org/openmotif/supporters/metrolink/license.html)\n\
    - Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)\n\

--- a/features/org.springframework.ide.eclipse.ajdt.feature.source/feature.properties
+++ b/features/org.springframework.ide.eclipse.ajdt.feature.source/feature.properties
@@ -66,8 +66,8 @@ Note: if a Feature made available by the Spring IDE project is installed using t
 THE ABOUTS, FEATURE LICENSES, AND FEATURE UPDATE LICENSES MAY REFER TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS. SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):\n\
 \n\
    - Common Public License Version 1.0 (available at http://www.eclipse.org/legal/cpl-v10.html)\n\
-   - Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)\n\
-   - Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)\n\
+   - Apache Software License 1.1 (available at https://www.apache.org/licenses/LICENSE)\n\
+   - Apache Software License 2.0 (available at https://www.apache.org/licenses/LICENSE-2.0)\n\
    - IBM Public License 1.0 (available at http://oss.software.ibm.com/developerworks/opensource/license10.html)\n\
    - Metro Link Public License 1.00 (available at http://www.opengroup.org/openmotif/supporters/metrolink/license.html)\n\
    - Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)\n\

--- a/features/org.springframework.ide.eclipse.ajdt.feature/feature.properties
+++ b/features/org.springframework.ide.eclipse.ajdt.feature/feature.properties
@@ -65,8 +65,8 @@ Note: if a Feature made available by the Spring IDE project is installed using t
 THE ABOUTS, FEATURE LICENSES, AND FEATURE UPDATE LICENSES MAY REFER TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS. SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):\n\
 \n\
    - Common Public License Version 1.0 (available at http://www.eclipse.org/legal/cpl-v10.html)\n\
-   - Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)\n\
-   - Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)\n\
+   - Apache Software License 1.1 (available at https://www.apache.org/licenses/LICENSE)\n\
+   - Apache Software License 2.0 (available at https://www.apache.org/licenses/LICENSE-2.0)\n\
    - IBM Public License 1.0 (available at http://oss.software.ibm.com/developerworks/opensource/license10.html)\n\
    - Metro Link Public License 1.00 (available at http://www.opengroup.org/openmotif/supporters/metrolink/license.html)\n\
    - Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)\n\

--- a/features/org.springframework.ide.eclipse.aop.feature.source/feature.properties
+++ b/features/org.springframework.ide.eclipse.aop.feature.source/feature.properties
@@ -66,8 +66,8 @@ Note: if a Feature made available by the Spring IDE project is installed using t
 THE ABOUTS, FEATURE LICENSES, AND FEATURE UPDATE LICENSES MAY REFER TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS. SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):\n\
 \n\
    - Common Public License Version 1.0 (available at http://www.eclipse.org/legal/cpl-v10.html)\n\
-   - Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)\n\
-   - Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)\n\
+   - Apache Software License 1.1 (available at https://www.apache.org/licenses/LICENSE)\n\
+   - Apache Software License 2.0 (available at https://www.apache.org/licenses/LICENSE-2.0)\n\
    - IBM Public License 1.0 (available at http://oss.software.ibm.com/developerworks/opensource/license10.html)\n\
    - Metro Link Public License 1.00 (available at http://www.opengroup.org/openmotif/supporters/metrolink/license.html)\n\
    - Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)\n\

--- a/features/org.springframework.ide.eclipse.aop.feature/feature.properties
+++ b/features/org.springframework.ide.eclipse.aop.feature/feature.properties
@@ -66,8 +66,8 @@ Note: if a Feature made available by the Spring IDE project is installed using t
 THE ABOUTS, FEATURE LICENSES, AND FEATURE UPDATE LICENSES MAY REFER TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS. SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):\n\
 \n\
    - Common Public License Version 1.0 (available at http://www.eclipse.org/legal/cpl-v10.html)\n\
-   - Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)\n\
-   - Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)\n\
+   - Apache Software License 1.1 (available at https://www.apache.org/licenses/LICENSE)\n\
+   - Apache Software License 2.0 (available at https://www.apache.org/licenses/LICENSE-2.0)\n\
    - IBM Public License 1.0 (available at http://oss.software.ibm.com/developerworks/opensource/license10.html)\n\
    - Metro Link Public License 1.00 (available at http://www.opengroup.org/openmotif/supporters/metrolink/license.html)\n\
    - Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)\n\

--- a/features/org.springframework.ide.eclipse.autowire.feature.source/feature.properties
+++ b/features/org.springframework.ide.eclipse.autowire.feature.source/feature.properties
@@ -66,8 +66,8 @@ Note: if a Feature made available by the Spring IDE project is installed using t
 THE ABOUTS, FEATURE LICENSES, AND FEATURE UPDATE LICENSES MAY REFER TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS. SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):\n\
 \n\
    - Common Public License Version 1.0 (available at http://www.eclipse.org/legal/cpl-v10.html)\n\
-   - Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)\n\
-   - Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)\n\
+   - Apache Software License 1.1 (available at https://www.apache.org/licenses/LICENSE)\n\
+   - Apache Software License 2.0 (available at https://www.apache.org/licenses/LICENSE-2.0)\n\
    - IBM Public License 1.0 (available at http://oss.software.ibm.com/developerworks/opensource/license10.html)\n\
    - Metro Link Public License 1.00 (available at http://www.opengroup.org/openmotif/supporters/metrolink/license.html)\n\
    - Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)\n\

--- a/features/org.springframework.ide.eclipse.autowire.feature/feature.properties
+++ b/features/org.springframework.ide.eclipse.autowire.feature/feature.properties
@@ -65,8 +65,8 @@ Note: if a Feature made available by the Spring IDE project is installed using t
 THE ABOUTS, FEATURE LICENSES, AND FEATURE UPDATE LICENSES MAY REFER TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS. SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):\n\
 \n\
    - Common Public License Version 1.0 (available at http://www.eclipse.org/legal/cpl-v10.html)\n\
-   - Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)\n\
-   - Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)\n\
+   - Apache Software License 1.1 (available at https://www.apache.org/licenses/LICENSE)\n\
+   - Apache Software License 2.0 (available at https://www.apache.org/licenses/LICENSE-2.0)\n\
    - IBM Public License 1.0 (available at http://oss.software.ibm.com/developerworks/opensource/license10.html)\n\
    - Metro Link Public License 1.00 (available at http://www.opengroup.org/openmotif/supporters/metrolink/license.html)\n\
    - Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)\n\

--- a/features/org.springframework.ide.eclipse.batch.feature.source/feature.properties
+++ b/features/org.springframework.ide.eclipse.batch.feature.source/feature.properties
@@ -65,8 +65,8 @@ Note: if a Feature made available by the Spring IDE project is installed using t
 THE ABOUTS, FEATURE LICENSES, AND FEATURE UPDATE LICENSES MAY REFER TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS. SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):\n\
 \n\
    - Common Public License Version 1.0 (available at http://www.eclipse.org/legal/cpl-v10.html)\n\
-   - Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)\n\
-   - Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)\n\
+   - Apache Software License 1.1 (available at https://www.apache.org/licenses/LICENSE)\n\
+   - Apache Software License 2.0 (available at https://www.apache.org/licenses/LICENSE-2.0)\n\
    - IBM Public License 1.0 (available at http://oss.software.ibm.com/developerworks/opensource/license10.html)\n\
    - Metro Link Public License 1.00 (available at http://www.opengroup.org/openmotif/supporters/metrolink/license.html)\n\
    - Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)\n\

--- a/features/org.springframework.ide.eclipse.batch.feature/feature.properties
+++ b/features/org.springframework.ide.eclipse.batch.feature/feature.properties
@@ -65,8 +65,8 @@ Note: if a Feature made available by the Spring IDE project is installed using t
 THE ABOUTS, FEATURE LICENSES, AND FEATURE UPDATE LICENSES MAY REFER TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS. SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):\n\
 \n\
    - Common Public License Version 1.0 (available at http://www.eclipse.org/legal/cpl-v10.html)\n\
-   - Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)\n\
-   - Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)\n\
+   - Apache Software License 1.1 (available at https://www.apache.org/licenses/LICENSE)\n\
+   - Apache Software License 2.0 (available at https://www.apache.org/licenses/LICENSE-2.0)\n\
    - IBM Public License 1.0 (available at http://oss.software.ibm.com/developerworks/opensource/license10.html)\n\
    - Metro Link Public License 1.00 (available at http://www.opengroup.org/openmotif/supporters/metrolink/license.html)\n\
    - Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)\n\

--- a/features/org.springframework.ide.eclipse.boot.dash.feature.source/feature.properties
+++ b/features/org.springframework.ide.eclipse.boot.dash.feature.source/feature.properties
@@ -65,8 +65,8 @@ Note: if a Feature made available by the Spring IDE project is installed using t
 THE ABOUTS, FEATURE LICENSES, AND FEATURE UPDATE LICENSES MAY REFER TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS. SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):\n\
 \n\
    - Common Public License Version 1.0 (available at http://www.eclipse.org/legal/cpl-v10.html)\n\
-   - Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)\n\
-   - Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)\n\
+   - Apache Software License 1.1 (available at https://www.apache.org/licenses/LICENSE)\n\
+   - Apache Software License 2.0 (available at https://www.apache.org/licenses/LICENSE-2.0)\n\
    - IBM Public License 1.0 (available at http://oss.software.ibm.com/developerworks/opensource/license10.html)\n\
    - Metro Link Public License 1.00 (available at http://www.opengroup.org/openmotif/supporters/metrolink/license.html)\n\
    - Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)\n\

--- a/features/org.springframework.ide.eclipse.boot.dash.feature/feature.properties
+++ b/features/org.springframework.ide.eclipse.boot.dash.feature/feature.properties
@@ -65,8 +65,8 @@ Note: if a Feature made available by the Spring IDE project is installed using t
 THE ABOUTS, FEATURE LICENSES, AND FEATURE UPDATE LICENSES MAY REFER TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS. SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):\n\
 \n\
    - Common Public License Version 1.0 (available at http://www.eclipse.org/legal/cpl-v10.html)\n\
-   - Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)\n\
-   - Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)\n\
+   - Apache Software License 1.1 (available at https://www.apache.org/licenses/LICENSE)\n\
+   - Apache Software License 2.0 (available at https://www.apache.org/licenses/LICENSE-2.0)\n\
    - IBM Public License 1.0 (available at http://oss.software.ibm.com/developerworks/opensource/license10.html)\n\
    - Metro Link Public License 1.00 (available at http://www.opengroup.org/openmotif/supporters/metrolink/license.html)\n\
    - Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)\n\

--- a/features/org.springframework.ide.eclipse.boot.feature.source/feature.properties
+++ b/features/org.springframework.ide.eclipse.boot.feature.source/feature.properties
@@ -65,8 +65,8 @@ Note: if a Feature made available by the Spring IDE project is installed using t
 THE ABOUTS, FEATURE LICENSES, AND FEATURE UPDATE LICENSES MAY REFER TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS. SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):\n\
 \n\
    - Common Public License Version 1.0 (available at http://www.eclipse.org/legal/cpl-v10.html)\n\
-   - Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)\n\
-   - Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)\n\
+   - Apache Software License 1.1 (available at https://www.apache.org/licenses/LICENSE)\n\
+   - Apache Software License 2.0 (available at https://www.apache.org/licenses/LICENSE-2.0)\n\
    - IBM Public License 1.0 (available at http://oss.software.ibm.com/developerworks/opensource/license10.html)\n\
    - Metro Link Public License 1.00 (available at http://www.opengroup.org/openmotif/supporters/metrolink/license.html)\n\
    - Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)\n\

--- a/features/org.springframework.ide.eclipse.boot.feature/feature.properties
+++ b/features/org.springframework.ide.eclipse.boot.feature/feature.properties
@@ -65,8 +65,8 @@ Note: if a Feature made available by the Spring IDE project is installed using t
 THE ABOUTS, FEATURE LICENSES, AND FEATURE UPDATE LICENSES MAY REFER TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS. SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):\n\
 \n\
    - Common Public License Version 1.0 (available at http://www.eclipse.org/legal/cpl-v10.html)\n\
-   - Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)\n\
-   - Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)\n\
+   - Apache Software License 1.1 (available at https://www.apache.org/licenses/LICENSE)\n\
+   - Apache Software License 2.0 (available at https://www.apache.org/licenses/LICENSE-2.0)\n\
    - IBM Public License 1.0 (available at http://oss.software.ibm.com/developerworks/opensource/license10.html)\n\
    - Metro Link Public License 1.00 (available at http://www.opengroup.org/openmotif/supporters/metrolink/license.html)\n\
    - Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)\n\

--- a/features/org.springframework.ide.eclipse.cft.feature.source/feature.properties
+++ b/features/org.springframework.ide.eclipse.cft.feature.source/feature.properties
@@ -65,8 +65,8 @@ Note: if a Feature made available by the Spring IDE project is installed using t
 THE ABOUTS, FEATURE LICENSES, AND FEATURE UPDATE LICENSES MAY REFER TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS. SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):\n\
 \n\
    - Common Public License Version 1.0 (available at http://www.eclipse.org/legal/cpl-v10.html)\n\
-   - Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)\n\
-   - Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)\n\
+   - Apache Software License 1.1 (available at https://www.apache.org/licenses/LICENSE)\n\
+   - Apache Software License 2.0 (available at https://www.apache.org/licenses/LICENSE-2.0)\n\
    - IBM Public License 1.0 (available at http://oss.software.ibm.com/developerworks/opensource/license10.html)\n\
    - Metro Link Public License 1.00 (available at http://www.opengroup.org/openmotif/supporters/metrolink/license.html)\n\
    - Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)\n\

--- a/features/org.springframework.ide.eclipse.cft.feature/feature.properties
+++ b/features/org.springframework.ide.eclipse.cft.feature/feature.properties
@@ -65,8 +65,8 @@ Note: if a Feature made available by the Spring IDE project is installed using t
 THE ABOUTS, FEATURE LICENSES, AND FEATURE UPDATE LICENSES MAY REFER TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS. SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):\n\
 \n\
    - Common Public License Version 1.0 (available at http://www.eclipse.org/legal/cpl-v10.html)\n\
-   - Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)\n\
-   - Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)\n\
+   - Apache Software License 1.1 (available at https://www.apache.org/licenses/LICENSE)\n\
+   - Apache Software License 2.0 (available at https://www.apache.org/licenses/LICENSE-2.0)\n\
    - IBM Public License 1.0 (available at http://oss.software.ibm.com/developerworks/opensource/license10.html)\n\
    - Metro Link Public License 1.00 (available at http://www.opengroup.org/openmotif/supporters/metrolink/license.html)\n\
    - Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)\n\

--- a/features/org.springframework.ide.eclipse.data.feature.source/feature.properties
+++ b/features/org.springframework.ide.eclipse.data.feature.source/feature.properties
@@ -65,8 +65,8 @@ Note: if a Feature made available by the Spring IDE project is installed using t
 THE ABOUTS, FEATURE LICENSES, AND FEATURE UPDATE LICENSES MAY REFER TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS. SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):\n\
 \n\
    - Common Public License Version 1.0 (available at http://www.eclipse.org/legal/cpl-v10.html)\n\
-   - Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)\n\
-   - Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)\n\
+   - Apache Software License 1.1 (available at https://www.apache.org/licenses/LICENSE)\n\
+   - Apache Software License 2.0 (available at https://www.apache.org/licenses/LICENSE-2.0)\n\
    - IBM Public License 1.0 (available at http://oss.software.ibm.com/developerworks/opensource/license10.html)\n\
    - Metro Link Public License 1.00 (available at http://www.opengroup.org/openmotif/supporters/metrolink/license.html)\n\
    - Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)\n\

--- a/features/org.springframework.ide.eclipse.data.feature/feature.properties
+++ b/features/org.springframework.ide.eclipse.data.feature/feature.properties
@@ -65,8 +65,8 @@ Note: if a Feature made available by the Spring IDE project is installed using t
 THE ABOUTS, FEATURE LICENSES, AND FEATURE UPDATE LICENSES MAY REFER TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS. SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):\n\
 \n\
    - Common Public License Version 1.0 (available at http://www.eclipse.org/legal/cpl-v10.html)\n\
-   - Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)\n\
-   - Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)\n\
+   - Apache Software License 1.1 (available at https://www.apache.org/licenses/LICENSE)\n\
+   - Apache Software License 2.0 (available at https://www.apache.org/licenses/LICENSE-2.0)\n\
    - IBM Public License 1.0 (available at http://oss.software.ibm.com/developerworks/opensource/license10.html)\n\
    - Metro Link Public License 1.00 (available at http://www.opengroup.org/openmotif/supporters/metrolink/license.html)\n\
    - Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)\n\

--- a/features/org.springframework.ide.eclipse.feature.source/feature.properties
+++ b/features/org.springframework.ide.eclipse.feature.source/feature.properties
@@ -65,8 +65,8 @@ Note: if a Feature made available by the Spring IDE project is installed using t
 THE ABOUTS, FEATURE LICENSES, AND FEATURE UPDATE LICENSES MAY REFER TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS. SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):\n\
 \n\
    - Common Public License Version 1.0 (available at http://www.eclipse.org/legal/cpl-v10.html)\n\
-   - Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)\n\
-   - Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)\n\
+   - Apache Software License 1.1 (available at https://www.apache.org/licenses/LICENSE)\n\
+   - Apache Software License 2.0 (available at https://www.apache.org/licenses/LICENSE-2.0)\n\
    - IBM Public License 1.0 (available at http://oss.software.ibm.com/developerworks/opensource/license10.html)\n\
    - Metro Link Public License 1.00 (available at http://www.opengroup.org/openmotif/supporters/metrolink/license.html)\n\
    - Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)\n\

--- a/features/org.springframework.ide.eclipse.feature/feature.properties
+++ b/features/org.springframework.ide.eclipse.feature/feature.properties
@@ -65,8 +65,8 @@ Note: if a Feature made available by the Spring IDE project is installed using t
 THE ABOUTS, FEATURE LICENSES, AND FEATURE UPDATE LICENSES MAY REFER TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS. SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):\n\
 \n\
    - Common Public License Version 1.0 (available at http://www.eclipse.org/legal/cpl-v10.html)\n\
-   - Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)\n\
-   - Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)\n\
+   - Apache Software License 1.1 (available at https://www.apache.org/licenses/LICENSE)\n\
+   - Apache Software License 2.0 (available at https://www.apache.org/licenses/LICENSE-2.0)\n\
    - IBM Public License 1.0 (available at http://oss.software.ibm.com/developerworks/opensource/license10.html)\n\
    - Metro Link Public License 1.00 (available at http://www.opengroup.org/openmotif/supporters/metrolink/license.html)\n\
    - Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)\n\

--- a/features/org.springframework.ide.eclipse.groovy.tests.feature/feature.properties
+++ b/features/org.springframework.ide.eclipse.groovy.tests.feature/feature.properties
@@ -65,8 +65,8 @@ Note: if a Feature made available by the Spring IDE project is installed using t
 THE ABOUTS, FEATURE LICENSES, AND FEATURE UPDATE LICENSES MAY REFER TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS. SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):\n\
 \n\
    - Common Public License Version 1.0 (available at http://www.eclipse.org/legal/cpl-v10.html)\n\
-   - Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)\n\
-   - Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)\n\
+   - Apache Software License 1.1 (available at https://www.apache.org/licenses/LICENSE)\n\
+   - Apache Software License 2.0 (available at https://www.apache.org/licenses/LICENSE-2.0)\n\
    - IBM Public License 1.0 (available at http://oss.software.ibm.com/developerworks/opensource/license10.html)\n\
    - Metro Link Public License 1.00 (available at http://www.opengroup.org/openmotif/supporters/metrolink/license.html)\n\
    - Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)\n\

--- a/features/org.springframework.ide.eclipse.integration.feature.source/feature.properties
+++ b/features/org.springframework.ide.eclipse.integration.feature.source/feature.properties
@@ -65,8 +65,8 @@ Note: if a Feature made available by the Spring IDE project is installed using t
 THE ABOUTS, FEATURE LICENSES, AND FEATURE UPDATE LICENSES MAY REFER TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS. SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):\n\
 \n\
    - Common Public License Version 1.0 (available at http://www.eclipse.org/legal/cpl-v10.html)\n\
-   - Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)\n\
-   - Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)\n\
+   - Apache Software License 1.1 (available at https://www.apache.org/licenses/LICENSE)\n\
+   - Apache Software License 2.0 (available at https://www.apache.org/licenses/LICENSE-2.0)\n\
    - IBM Public License 1.0 (available at http://oss.software.ibm.com/developerworks/opensource/license10.html)\n\
    - Metro Link Public License 1.00 (available at http://www.opengroup.org/openmotif/supporters/metrolink/license.html)\n\
    - Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)\n\

--- a/features/org.springframework.ide.eclipse.integration.feature/feature.properties
+++ b/features/org.springframework.ide.eclipse.integration.feature/feature.properties
@@ -65,8 +65,8 @@ Note: if a Feature made available by the Spring IDE project is installed using t
 THE ABOUTS, FEATURE LICENSES, AND FEATURE UPDATE LICENSES MAY REFER TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS. SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):\n\
 \n\
    - Common Public License Version 1.0 (available at http://www.eclipse.org/legal/cpl-v10.html)\n\
-   - Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)\n\
-   - Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)\n\
+   - Apache Software License 1.1 (available at https://www.apache.org/licenses/LICENSE)\n\
+   - Apache Software License 2.0 (available at https://www.apache.org/licenses/LICENSE-2.0)\n\
    - IBM Public License 1.0 (available at http://oss.software.ibm.com/developerworks/opensource/license10.html)\n\
    - Metro Link Public License 1.00 (available at http://www.opengroup.org/openmotif/supporters/metrolink/license.html)\n\
    - Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)\n\

--- a/features/org.springframework.ide.eclipse.maven.feature.source/feature.properties
+++ b/features/org.springframework.ide.eclipse.maven.feature.source/feature.properties
@@ -65,8 +65,8 @@ Note: if a Feature made available by the Spring IDE project is installed using t
 THE ABOUTS, FEATURE LICENSES, AND FEATURE UPDATE LICENSES MAY REFER TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS. SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):\n\
 \n\
    - Common Public License Version 1.0 (available at http://www.eclipse.org/legal/cpl-v10.html)\n\
-   - Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)\n\
-   - Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)\n\
+   - Apache Software License 1.1 (available at https://www.apache.org/licenses/LICENSE)\n\
+   - Apache Software License 2.0 (available at https://www.apache.org/licenses/LICENSE-2.0)\n\
    - IBM Public License 1.0 (available at http://oss.software.ibm.com/developerworks/opensource/license10.html)\n\
    - Metro Link Public License 1.00 (available at http://www.opengroup.org/openmotif/supporters/metrolink/license.html)\n\
    - Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)\n\

--- a/features/org.springframework.ide.eclipse.maven.feature/feature.properties
+++ b/features/org.springframework.ide.eclipse.maven.feature/feature.properties
@@ -65,8 +65,8 @@ Note: if a Feature made available by the Spring IDE project is installed using t
 THE ABOUTS, FEATURE LICENSES, AND FEATURE UPDATE LICENSES MAY REFER TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS. SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):\n\
 \n\
    - Common Public License Version 1.0 (available at http://www.eclipse.org/legal/cpl-v10.html)\n\
-   - Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)\n\
-   - Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)\n\
+   - Apache Software License 1.1 (available at https://www.apache.org/licenses/LICENSE)\n\
+   - Apache Software License 2.0 (available at https://www.apache.org/licenses/LICENSE-2.0)\n\
    - IBM Public License 1.0 (available at http://oss.software.ibm.com/developerworks/opensource/license10.html)\n\
    - Metro Link Public License 1.00 (available at http://www.opengroup.org/openmotif/supporters/metrolink/license.html)\n\
    - Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)\n\

--- a/features/org.springframework.ide.eclipse.mylyn.feature.source/feature.properties
+++ b/features/org.springframework.ide.eclipse.mylyn.feature.source/feature.properties
@@ -66,8 +66,8 @@ Note: if a Feature made available by the Spring IDE project is installed using t
 THE ABOUTS, FEATURE LICENSES, AND FEATURE UPDATE LICENSES MAY REFER TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS. SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):\n\
 \n\
    - Common Public License Version 1.0 (available at http://www.eclipse.org/legal/cpl-v10.html)\n\
-   - Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)\n\
-   - Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)\n\
+   - Apache Software License 1.1 (available at https://www.apache.org/licenses/LICENSE)\n\
+   - Apache Software License 2.0 (available at https://www.apache.org/licenses/LICENSE-2.0)\n\
    - IBM Public License 1.0 (available at http://oss.software.ibm.com/developerworks/opensource/license10.html)\n\
    - Metro Link Public License 1.00 (available at http://www.opengroup.org/openmotif/supporters/metrolink/license.html)\n\
    - Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)\n\

--- a/features/org.springframework.ide.eclipse.mylyn.feature/feature.properties
+++ b/features/org.springframework.ide.eclipse.mylyn.feature/feature.properties
@@ -66,8 +66,8 @@ Note: if a Feature made available by the Spring IDE project is installed using t
 THE ABOUTS, FEATURE LICENSES, AND FEATURE UPDATE LICENSES MAY REFER TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS. SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):\n\
 \n\
    - Common Public License Version 1.0 (available at http://www.eclipse.org/legal/cpl-v10.html)\n\
-   - Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)\n\
-   - Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)\n\
+   - Apache Software License 1.1 (available at https://www.apache.org/licenses/LICENSE)\n\
+   - Apache Software License 2.0 (available at https://www.apache.org/licenses/LICENSE-2.0)\n\
    - IBM Public License 1.0 (available at http://oss.software.ibm.com/developerworks/opensource/license10.html)\n\
    - Metro Link Public License 1.00 (available at http://www.opengroup.org/openmotif/supporters/metrolink/license.html)\n\
    - Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)\n\

--- a/features/org.springframework.ide.eclipse.osgi.feature.source/feature.properties
+++ b/features/org.springframework.ide.eclipse.osgi.feature.source/feature.properties
@@ -66,8 +66,8 @@ Note: if a Feature made available by the Spring IDE project is installed using t
 THE ABOUTS, FEATURE LICENSES, AND FEATURE UPDATE LICENSES MAY REFER TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS. SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):\n\
 \n\
    - Common Public License Version 1.0 (available at http://www.eclipse.org/legal/cpl-v10.html)\n\
-   - Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)\n\
-   - Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)\n\
+   - Apache Software License 1.1 (available at https://www.apache.org/licenses/LICENSE)\n\
+   - Apache Software License 2.0 (available at https://www.apache.org/licenses/LICENSE-2.0)\n\
    - IBM Public License 1.0 (available at http://oss.software.ibm.com/developerworks/opensource/license10.html)\n\
    - Metro Link Public License 1.00 (available at http://www.opengroup.org/openmotif/supporters/metrolink/license.html)\n\
    - Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)\n\

--- a/features/org.springframework.ide.eclipse.osgi.feature/feature.properties
+++ b/features/org.springframework.ide.eclipse.osgi.feature/feature.properties
@@ -65,8 +65,8 @@ Note: if a Feature made available by the Spring IDE project is installed using t
 THE ABOUTS, FEATURE LICENSES, AND FEATURE UPDATE LICENSES MAY REFER TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS. SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):\n\
 \n\
    - Common Public License Version 1.0 (available at http://www.eclipse.org/legal/cpl-v10.html)\n\
-   - Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)\n\
-   - Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)\n\
+   - Apache Software License 1.1 (available at https://www.apache.org/licenses/LICENSE)\n\
+   - Apache Software License 2.0 (available at https://www.apache.org/licenses/LICENSE-2.0)\n\
    - IBM Public License 1.0 (available at http://oss.software.ibm.com/developerworks/opensource/license10.html)\n\
    - Metro Link Public License 1.00 (available at http://www.opengroup.org/openmotif/supporters/metrolink/license.html)\n\
    - Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)\n\

--- a/features/org.springframework.ide.eclipse.roo.feature.source/feature.properties
+++ b/features/org.springframework.ide.eclipse.roo.feature.source/feature.properties
@@ -65,8 +65,8 @@ Note: if a Feature made available by the Spring IDE project is installed using t
 THE ABOUTS, FEATURE LICENSES, AND FEATURE UPDATE LICENSES MAY REFER TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS. SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):\n\
 \n\
    - Common Public License Version 1.0 (available at http://www.eclipse.org/legal/cpl-v10.html)\n\
-   - Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)\n\
-   - Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)\n\
+   - Apache Software License 1.1 (available at https://www.apache.org/licenses/LICENSE)\n\
+   - Apache Software License 2.0 (available at https://www.apache.org/licenses/LICENSE-2.0)\n\
    - IBM Public License 1.0 (available at http://oss.software.ibm.com/developerworks/opensource/license10.html)\n\
    - Metro Link Public License 1.00 (available at http://www.opengroup.org/openmotif/supporters/metrolink/license.html)\n\
    - Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)\n\

--- a/features/org.springframework.ide.eclipse.roo.feature/feature.properties
+++ b/features/org.springframework.ide.eclipse.roo.feature/feature.properties
@@ -65,8 +65,8 @@ Note: if a Feature made available by the Spring IDE project is installed using t
 THE ABOUTS, FEATURE LICENSES, AND FEATURE UPDATE LICENSES MAY REFER TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS. SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):\n\
 \n\
    - Common Public License Version 1.0 (available at http://www.eclipse.org/legal/cpl-v10.html)\n\
-   - Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)\n\
-   - Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)\n\
+   - Apache Software License 1.1 (available at https://www.apache.org/licenses/LICENSE)\n\
+   - Apache Software License 2.0 (available at https://www.apache.org/licenses/LICENSE-2.0)\n\
    - IBM Public License 1.0 (available at http://oss.software.ibm.com/developerworks/opensource/license10.html)\n\
    - Metro Link Public License 1.00 (available at http://www.opengroup.org/openmotif/supporters/metrolink/license.html)\n\
    - Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)\n\

--- a/features/org.springframework.ide.eclipse.security.feature.source/feature.properties
+++ b/features/org.springframework.ide.eclipse.security.feature.source/feature.properties
@@ -66,8 +66,8 @@ Note: if a Feature made available by the Spring IDE project is installed using t
 THE ABOUTS, FEATURE LICENSES, AND FEATURE UPDATE LICENSES MAY REFER TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS. SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):\n\
 \n\
    - Common Public License Version 1.0 (available at http://www.eclipse.org/legal/cpl-v10.html)\n\
-   - Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)\n\
-   - Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)\n\
+   - Apache Software License 1.1 (available at https://www.apache.org/licenses/LICENSE)\n\
+   - Apache Software License 2.0 (available at https://www.apache.org/licenses/LICENSE-2.0)\n\
    - IBM Public License 1.0 (available at http://oss.software.ibm.com/developerworks/opensource/license10.html)\n\
    - Metro Link Public License 1.00 (available at http://www.opengroup.org/openmotif/supporters/metrolink/license.html)\n\
    - Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)\n\

--- a/features/org.springframework.ide.eclipse.security.feature/feature.properties
+++ b/features/org.springframework.ide.eclipse.security.feature/feature.properties
@@ -65,8 +65,8 @@ Note: if a Feature made available by the Spring IDE project is installed using t
 THE ABOUTS, FEATURE LICENSES, AND FEATURE UPDATE LICENSES MAY REFER TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS. SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):\n\
 \n\
    - Common Public License Version 1.0 (available at http://www.eclipse.org/legal/cpl-v10.html)\n\
-   - Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)\n\
-   - Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)\n\
+   - Apache Software License 1.1 (available at https://www.apache.org/licenses/LICENSE)\n\
+   - Apache Software License 2.0 (available at https://www.apache.org/licenses/LICENSE-2.0)\n\
    - IBM Public License 1.0 (available at http://oss.software.ibm.com/developerworks/opensource/license10.html)\n\
    - Metro Link Public License 1.00 (available at http://www.opengroup.org/openmotif/supporters/metrolink/license.html)\n\
    - Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)\n\

--- a/features/org.springframework.ide.eclipse.tests.feature/feature.properties
+++ b/features/org.springframework.ide.eclipse.tests.feature/feature.properties
@@ -65,8 +65,8 @@ Note: if a Feature made available by the Spring IDE project is installed using t
 THE ABOUTS, FEATURE LICENSES, AND FEATURE UPDATE LICENSES MAY REFER TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS. SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):\n\
 \n\
    - Common Public License Version 1.0 (available at http://www.eclipse.org/legal/cpl-v10.html)\n\
-   - Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)\n\
-   - Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)\n\
+   - Apache Software License 1.1 (available at https://www.apache.org/licenses/LICENSE)\n\
+   - Apache Software License 2.0 (available at https://www.apache.org/licenses/LICENSE-2.0)\n\
    - IBM Public License 1.0 (available at http://oss.software.ibm.com/developerworks/opensource/license10.html)\n\
    - Metro Link Public License 1.00 (available at http://www.opengroup.org/openmotif/supporters/metrolink/license.html)\n\
    - Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)\n\

--- a/features/org.springframework.ide.eclipse.webflow.feature.source/feature.properties
+++ b/features/org.springframework.ide.eclipse.webflow.feature.source/feature.properties
@@ -66,8 +66,8 @@ Note: if a Feature made available by the Spring IDE project is installed using t
 THE ABOUTS, FEATURE LICENSES, AND FEATURE UPDATE LICENSES MAY REFER TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS. SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):\n\
 \n\
    - Common Public License Version 1.0 (available at http://www.eclipse.org/legal/cpl-v10.html)\n\
-   - Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)\n\
-   - Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)\n\
+   - Apache Software License 1.1 (available at https://www.apache.org/licenses/LICENSE)\n\
+   - Apache Software License 2.0 (available at https://www.apache.org/licenses/LICENSE-2.0)\n\
    - IBM Public License 1.0 (available at http://oss.software.ibm.com/developerworks/opensource/license10.html)\n\
    - Metro Link Public License 1.00 (available at http://www.opengroup.org/openmotif/supporters/metrolink/license.html)\n\
    - Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)\n\

--- a/features/org.springframework.ide.eclipse.webflow.feature/feature.properties
+++ b/features/org.springframework.ide.eclipse.webflow.feature/feature.properties
@@ -65,8 +65,8 @@ Note: if a Feature made available by the Spring IDE project is installed using t
 THE ABOUTS, FEATURE LICENSES, AND FEATURE UPDATE LICENSES MAY REFER TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS. SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):\n\
 \n\
    - Common Public License Version 1.0 (available at http://www.eclipse.org/legal/cpl-v10.html)\n\
-   - Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)\n\
-   - Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)\n\
+   - Apache Software License 1.1 (available at https://www.apache.org/licenses/LICENSE)\n\
+   - Apache Software License 2.0 (available at https://www.apache.org/licenses/LICENSE-2.0)\n\
    - IBM Public License 1.0 (available at http://oss.software.ibm.com/developerworks/opensource/license10.html)\n\
    - Metro Link Public License 1.00 (available at http://www.opengroup.org/openmotif/supporters/metrolink/license.html)\n\
    - Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)\n\

--- a/plugins/org.springframework.ide.eclipse.beans.core.tests/workspace/autowire/src/org/springframework/beans/factory/annotation/AutowiredAnnotationBeanPostProcessorTests.java
+++ b/plugins/org.springframework.ide.eclipse.beans.core.tests/workspace/autowire/src/org/springframework/beans/factory/annotation/AutowiredAnnotationBeanPostProcessorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.beans.core.tests/workspace/autowire/src/org/springframework/context/annotation/CommonAnnotationBeanPostProcessorTests.java
+++ b/plugins/org.springframework.ide.eclipse.beans.core.tests/workspace/autowire/src/org/springframework/context/annotation/CommonAnnotationBeanPostProcessorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.beans.core.tests/workspace/autowire/src/test/beans/BooleanTestBean.java
+++ b/plugins/org.springframework.ide.eclipse.beans.core.tests/workspace/autowire/src/test/beans/BooleanTestBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.beans.core.tests/workspace/autowire/src/test/beans/Colour.java
+++ b/plugins/org.springframework.ide.eclipse.beans.core.tests/workspace/autowire/src/test/beans/Colour.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.beans.core.tests/workspace/autowire/src/test/beans/CustomEnum.java
+++ b/plugins/org.springframework.ide.eclipse.beans.core.tests/workspace/autowire/src/test/beans/CustomEnum.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.beans.core.tests/workspace/autowire/src/test/beans/DerivedTestBean.java
+++ b/plugins/org.springframework.ide.eclipse.beans.core.tests/workspace/autowire/src/test/beans/DerivedTestBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.beans.core.tests/workspace/autowire/src/test/beans/DummyFactory.java
+++ b/plugins/org.springframework.ide.eclipse.beans.core.tests/workspace/autowire/src/test/beans/DummyFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.beans.core.tests/workspace/autowire/src/test/beans/GenericBean.java
+++ b/plugins/org.springframework.ide.eclipse.beans.core.tests/workspace/autowire/src/test/beans/GenericBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.beans.core.tests/workspace/autowire/src/test/beans/GenericIntegerBean.java
+++ b/plugins/org.springframework.ide.eclipse.beans.core.tests/workspace/autowire/src/test/beans/GenericIntegerBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.beans.core.tests/workspace/autowire/src/test/beans/GenericSetOfIntegerBean.java
+++ b/plugins/org.springframework.ide.eclipse.beans.core.tests/workspace/autowire/src/test/beans/GenericSetOfIntegerBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.beans.core.tests/workspace/autowire/src/test/beans/INestedTestBean.java
+++ b/plugins/org.springframework.ide.eclipse.beans.core.tests/workspace/autowire/src/test/beans/INestedTestBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.beans.core.tests/workspace/autowire/src/test/beans/IOther.java
+++ b/plugins/org.springframework.ide.eclipse.beans.core.tests/workspace/autowire/src/test/beans/IOther.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.beans.core.tests/workspace/autowire/src/test/beans/ITestBean.java
+++ b/plugins/org.springframework.ide.eclipse.beans.core.tests/workspace/autowire/src/test/beans/ITestBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.beans.core.tests/workspace/autowire/src/test/beans/IndexedTestBean.java
+++ b/plugins/org.springframework.ide.eclipse.beans.core.tests/workspace/autowire/src/test/beans/IndexedTestBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.beans.core.tests/workspace/autowire/src/test/beans/LifecycleBean.java
+++ b/plugins/org.springframework.ide.eclipse.beans.core.tests/workspace/autowire/src/test/beans/LifecycleBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.beans.core.tests/workspace/autowire/src/test/beans/NestedTestBean.java
+++ b/plugins/org.springframework.ide.eclipse.beans.core.tests/workspace/autowire/src/test/beans/NestedTestBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.beans.core.tests/workspace/autowire/src/test/beans/NumberTestBean.java
+++ b/plugins/org.springframework.ide.eclipse.beans.core.tests/workspace/autowire/src/test/beans/NumberTestBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.beans.core.tests/workspace/autowire/src/test/beans/PackageLevelVisibleBean.java
+++ b/plugins/org.springframework.ide.eclipse.beans.core.tests/workspace/autowire/src/test/beans/PackageLevelVisibleBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.beans.core.tests/workspace/autowire/src/test/beans/TestBean.java
+++ b/plugins/org.springframework.ide.eclipse.beans.core.tests/workspace/autowire/src/test/beans/TestBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.beans.core.tests/workspace/autowire/src/test/util/TestResourceUtils.java
+++ b/plugins/org.springframework.ide.eclipse.beans.core.tests/workspace/autowire/src/test/util/TestResourceUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.boot.dash/src/org/springframework/ide/eclipse/boot/dash/views/UpdatePasswordDialog.java
+++ b/plugins/org.springframework.ide.eclipse.boot.dash/src/org/springframework/ide/eclipse/boot/dash/views/UpdatePasswordDialog.java
@@ -18,7 +18,7 @@
  * Version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.boot.launch/src/org/springframework/ide/eclipse/boot/launch/console/BootConsolePageParticipant.java
+++ b/plugins/org.springframework.ide.eclipse.boot.launch/src/org/springframework/ide/eclipse/boot/launch/console/BootConsolePageParticipant.java
@@ -6,7 +6,7 @@
  * Version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.boot.properties.editor/src/org/springframework/boot/configurationmetadata/ConfigurationMetadataGroup.java
+++ b/plugins/org.springframework.ide.eclipse.boot.properties.editor/src/org/springframework/boot/configurationmetadata/ConfigurationMetadataGroup.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.boot.properties.editor/src/org/springframework/boot/configurationmetadata/ConfigurationMetadataHint.java
+++ b/plugins/org.springframework.ide.eclipse.boot.properties.editor/src/org/springframework/boot/configurationmetadata/ConfigurationMetadataHint.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.boot.properties.editor/src/org/springframework/boot/configurationmetadata/ConfigurationMetadataItem.java
+++ b/plugins/org.springframework.ide.eclipse.boot.properties.editor/src/org/springframework/boot/configurationmetadata/ConfigurationMetadataItem.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.boot.properties.editor/src/org/springframework/boot/configurationmetadata/ConfigurationMetadataProperty.java
+++ b/plugins/org.springframework.ide.eclipse.boot.properties.editor/src/org/springframework/boot/configurationmetadata/ConfigurationMetadataProperty.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.boot.properties.editor/src/org/springframework/boot/configurationmetadata/ConfigurationMetadataRepository.java
+++ b/plugins/org.springframework.ide.eclipse.boot.properties.editor/src/org/springframework/boot/configurationmetadata/ConfigurationMetadataRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.boot.properties.editor/src/org/springframework/boot/configurationmetadata/ConfigurationMetadataRepositoryJsonBuilder.java
+++ b/plugins/org.springframework.ide.eclipse.boot.properties.editor/src/org/springframework/boot/configurationmetadata/ConfigurationMetadataRepositoryJsonBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.boot.properties.editor/src/org/springframework/boot/configurationmetadata/ConfigurationMetadataSource.java
+++ b/plugins/org.springframework.ide.eclipse.boot.properties.editor/src/org/springframework/boot/configurationmetadata/ConfigurationMetadataSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.boot.properties.editor/src/org/springframework/boot/configurationmetadata/Deprecation.java
+++ b/plugins/org.springframework.ide.eclipse.boot.properties.editor/src/org/springframework/boot/configurationmetadata/Deprecation.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.boot.properties.editor/src/org/springframework/boot/configurationmetadata/DescriptionExtractor.java
+++ b/plugins/org.springframework.ide.eclipse.boot.properties.editor/src/org/springframework/boot/configurationmetadata/DescriptionExtractor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.boot.properties.editor/src/org/springframework/boot/configurationmetadata/Hints.java
+++ b/plugins/org.springframework.ide.eclipse.boot.properties.editor/src/org/springframework/boot/configurationmetadata/Hints.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.boot.properties.editor/src/org/springframework/boot/configurationmetadata/JsonReader.java
+++ b/plugins/org.springframework.ide.eclipse.boot.properties.editor/src/org/springframework/boot/configurationmetadata/JsonReader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.boot.properties.editor/src/org/springframework/boot/configurationmetadata/RawConfigurationMetadata.java
+++ b/plugins/org.springframework.ide.eclipse.boot.properties.editor/src/org/springframework/boot/configurationmetadata/RawConfigurationMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.boot.properties.editor/src/org/springframework/boot/configurationmetadata/SimpleConfigurationMetadataRepository.java
+++ b/plugins/org.springframework.ide.eclipse.boot.properties.editor/src/org/springframework/boot/configurationmetadata/SimpleConfigurationMetadataRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.boot.properties.editor/src/org/springframework/boot/configurationmetadata/ValueHint.java
+++ b/plugins/org.springframework.ide.eclipse.boot.properties.editor/src/org/springframework/boot/configurationmetadata/ValueHint.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.boot.properties.editor/src/org/springframework/boot/configurationmetadata/ValueProvider.java
+++ b/plugins/org.springframework.ide.eclipse.boot.properties.editor/src/org/springframework/boot/configurationmetadata/ValueProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.boot.properties.editor/src/org/springframework/boot/configurationmetadata/package-info.java
+++ b/plugins/org.springframework.ide.eclipse.boot.properties.editor/src/org/springframework/boot/configurationmetadata/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.boot.templates/resources/templates.xml
+++ b/plugins/org.springframework.ide.eclipse.boot.templates/resources/templates.xml
@@ -69,7 +69,7 @@ assertThat(${name:var}).isNotNull();${:importStatic('org.assertj.core.api.Assert
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.data.core/src/main/java/org/springframework/ide/eclipse/data/metadata/ui/RepositoriesBeanMetadata.java
+++ b/plugins/org.springframework.ide.eclipse.data.core/src/main/java/org/springframework/ide/eclipse/data/metadata/ui/RepositoriesBeanMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.data.core/src/main/java/org/springframework/ide/eclipse/data/metadata/ui/RepositoriesBeanMetadataProvider.java
+++ b/plugins/org.springframework.ide.eclipse.data.core/src/main/java/org/springframework/ide/eclipse/data/metadata/ui/RepositoriesBeanMetadataProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.osgi.blueprint/jaxb/blueprint.xsd
+++ b/plugins/org.springframework.ide.eclipse.osgi.blueprint/jaxb/blueprint.xsd
@@ -9,7 +9,7 @@
     * you may not use this file except in compliance with the License.
     * You may obtain a copy of the License at
     *
-    *      http://www.apache.org/licenses/LICENSE-2.0
+    *      https://www.apache.org/licenses/LICENSE-2.0
     *
     * Unless required by applicable law or agreed to in writing, software
     * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.osgi.blueprint/src/org/osgi/service/blueprint/container/Converter.java
+++ b/plugins/org.springframework.ide.eclipse.osgi.blueprint/src/org/osgi/service/blueprint/container/Converter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.osgi.blueprint/src/org/osgi/service/blueprint/container/ReifiedType.java
+++ b/plugins/org.springframework.ide.eclipse.osgi.blueprint/src/org/osgi/service/blueprint/container/ReifiedType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.osgi.blueprint/src/org/osgi/service/blueprint/container/ServiceUnavailableException.java
+++ b/plugins/org.springframework.ide.eclipse.osgi.blueprint/src/org/osgi/service/blueprint/container/ServiceUnavailableException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.quickfix.tests/workspace/autowire/src/org/springframework/beans/factory/annotation/AutowiredAnnotationBeanPostProcessorTests.java
+++ b/plugins/org.springframework.ide.eclipse.quickfix.tests/workspace/autowire/src/org/springframework/beans/factory/annotation/AutowiredAnnotationBeanPostProcessorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.quickfix.tests/workspace/autowire/src/test/beans/Colour.java
+++ b/plugins/org.springframework.ide.eclipse.quickfix.tests/workspace/autowire/src/test/beans/Colour.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.quickfix.tests/workspace/autowire/src/test/beans/INestedTestBean.java
+++ b/plugins/org.springframework.ide.eclipse.quickfix.tests/workspace/autowire/src/test/beans/INestedTestBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.quickfix.tests/workspace/autowire/src/test/beans/IOther.java
+++ b/plugins/org.springframework.ide.eclipse.quickfix.tests/workspace/autowire/src/test/beans/IOther.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.quickfix.tests/workspace/autowire/src/test/beans/ITestBean.java
+++ b/plugins/org.springframework.ide.eclipse.quickfix.tests/workspace/autowire/src/test/beans/ITestBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.quickfix.tests/workspace/autowire/src/test/beans/IndexedTestBean.java
+++ b/plugins/org.springframework.ide.eclipse.quickfix.tests/workspace/autowire/src/test/beans/IndexedTestBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.quickfix.tests/workspace/autowire/src/test/beans/NestedTestBean.java
+++ b/plugins/org.springframework.ide.eclipse.quickfix.tests/workspace/autowire/src/test/beans/NestedTestBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugins/org.springframework.ide.eclipse.quickfix.tests/workspace/autowire/src/test/beans/TestBean.java
+++ b/plugins/org.springframework.ide.eclipse.quickfix.tests/workspace/autowire/src/test/beans/TestBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/LICENSE with 36 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE ([https](https://www.apache.org/licenses/LICENSE) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 89 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).