### PR TITLE
Add support for async completions

### DIFF
--- a/plugins/org.springframework.ide.eclipse.boot.templates/plugin.xml
+++ b/plugins/org.springframework.ide.eclipse.boot.templates/plugin.xml
@@ -7,7 +7,7 @@
       <javaCompletionProposalComputer
             class="org.springframework.ide.eclipse.boot.templates.BootTemplateCompletionProposalComputer"
             activate="true"
-			categoryId="org.eclipse.jdt.ui.templateProposalCategory">
+			categoryId="org.eclipse.jdt.ui.templateProposalCategory" requiresUIThread="false">
 			<partition type="__dftl_partition_content_type"/>
       </javaCompletionProposalComputer>
     </extension>


### PR DESCRIPTION
Add support for async completion support in Eclipse 4.15. Without this when installing STS4 into eclipse 4.15 the whole installation switch to non-async mode because of this.